### PR TITLE
RESFRAME-2633 - Initialise distillery and remove from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,3 @@ bin
 dev.pem
 
 erts-9.3
-
-rel

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -1,0 +1,55 @@
+# Import all plugins from `rel/plugins`
+# They can then be used by adding `plugin MyPlugin` to
+# either an environment, or release definition, where
+# `MyPlugin` is the name of the plugin module.
+~w(rel plugins *.exs)
+|> Path.join()
+|> Path.wildcard()
+|> Enum.map(&Code.eval_file(&1))
+
+use Mix.Releases.Config,
+    # This sets the default release built by `mix release`
+    default_release: :default,
+    # This sets the default environment used by `mix release`
+    default_environment: Mix.env()
+
+# For a full list of config options for both releases
+# and environments, visit https://hexdocs.pm/distillery/config/distillery.html
+
+
+# You may define one or more environments in this file,
+# an environment's settings will override those of a release
+# when building in that environment, this combination of release
+# and environment configuration is called a profile
+
+environment :dev do
+  # If you are running Phoenix, you should make sure that
+  # server: true is set and the code reloader is disabled,
+  # even in dev mode.
+  # It is recommended that you build with MIX_ENV=prod and pass
+  # the --env flag to Distillery explicitly if you want to use
+  # dev mode.
+  set dev_mode: true
+  set include_erts: false
+  set cookie: :">e<&^mJuqsh@*1$]oSI_wFP.c>^k2jofo2VL^Kx|K.py3J;_I}|R^NZ(mY~DT}qx"
+end
+
+environment :prod do
+  set include_erts: true
+  set include_src: false
+  set cookie: :"]g?`x&<=d*c2GMVJ,LVNXFJfPpFa8}x]a2F6qH=7yv&,u_wTNV0FWLXgDx@ly;`*"
+  set vm_args: "rel/vm.args"
+end
+
+# You may define one or more releases in this file.
+# If you have not set a default release, or selected one
+# when running `mix release`, the first release in the file
+# will be used by default
+
+release :fetcher do
+  set version: current_version(:fetcher)
+  set applications: [
+    :runtime_tools
+  ]
+end
+

--- a/rel/plugins/.gitignore
+++ b/rel/plugins/.gitignore
@@ -1,0 +1,3 @@
+*.*
+!*.exs
+!.gitignore

--- a/rel/vm.args
+++ b/rel/vm.args
@@ -1,0 +1,30 @@
+## This file provide the arguments provided to the VM at startup
+## You can find a full list of flags and their behaviours at
+## http://erlang.org/doc/man/erl.html
+
+## Name of the node
+-name <%= release_name %>@127.0.0.1
+
+## Cookie for distributed erlang
+-setcookie <%= release.profile.cookie %>
+
+## Heartbeat management; auto-restarts VM if it dies or becomes unresponsive
+## (Disabled by default..use with caution!)
+##-heart
+
+## Enable kernel poll and a few async threads
+##+K true
+##+A 5
+## For OTP21+, the +A flag is not used anymore,
+## +SDio replace it to use dirty schedulers
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##-env ERL_MAX_PORTS 4096
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10
+
+# Enable SMP automatically based on availability
+# On OTP21+, this is not needed anymore.
+-smp auto


### PR DESCRIPTION
Run `mix release.init` to initialise distillery so that `mix release` can be used to create a deployable .tar.gz as a part of the CI steps