### PR TITLE
Finish renaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,8 +20,8 @@ erl_crash.dump
 *.ez
 
 # Ignore package tarball (built via "mix hex.build").
-fetcher-*.tar
-tars/fetcher.tar.gz
+mozart_fetcher-*.tar
+tars/mozart_fetcher.tar.gz
 
 bin
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build compile run
 
 build:
-	docker build -t fetcher .
+	docker build -t mozart_fetcher .
 
 compile:
 	docker run \
@@ -9,12 +9,12 @@ compile:
 		-v $(CURDIR):/opt/app \
 		-w /opt/app \
 		-e "DEV_CERT_PEM=$(DEV_CERT_PEM)" \
-		-e "APP_NAME=fetcher" \
+		-e "APP_NAME=mozart_fetcher" \
 		-e "APP_VERSION=0.1.0" \
 		-e "MIX_ENV=prod" \
-		-e "RELEASE_DIR=_build/prod/rel/fetcher/releases/0.1.0/" \
+		-e "RELEASE_DIR=_build/prod/rel/mozart_fetcher/releases/0.1.0/" \
 		-p 8080:8080 \
-		fetcher sh -c 'rm -rf _build tars && mkdir -p tars && mix release && cp _build/prod/rel/fetcher/releases/0.1.0/fetcher.tar.gz /opt/app/tars/'
+		mozart_fetcher sh -c 'rm -rf _build tars && mkdir -p tars && mix release && cp _build/prod/rel/mozart_fetcher/releases/0.1.0/mozart_fetcher.tar.gz /opt/app/tars/'
 
 run:
 	docker run \
@@ -23,7 +23,7 @@ run:
 		-v $(DEV_CERT_PEM):$(DEV_CERT_PEM) \
 		-w /opt/app \
 		-e "DEV_CERT_PEM=$(DEV_CERT_PEM)" \
-		-e "APP_NAME=fetcher" \
+		-e "APP_NAME=mozart_fetcher" \
 		-e "APP_VERSION=0.1.0" \
 		-p 8080:8080 \
-		fetcher sh -c 'mix run --no-halt'
+		mozart_fetcher sh -c 'mix run --no-halt'

--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ Requester returns a JSON collection of components in this format:
 ## Installation
 
 If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `fetcher` to your list of dependencies in `mix.exs`:
+by adding `mozart_fetcher` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
   [
-    {:fetcher, "~> 0.1.0"}
+    {:mozart_fetcher, "~> 0.1.0"}
   ]
 end
 ```
 
 Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
 and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/fetcher](https://hexdocs.pm/fetcher).
+be found at [https://hexdocs.pm/mozart_fetcher](https://hexdocs.pm/mozart_fetcher).
 
 
 ## Run locally

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,6 +27,6 @@ use Mix.Config
 # Configuration from the imported file will override the ones defined
 # here (which is why it is important to import them last).
 #
-config :fetcher, :environment, Mix.env()
+config :mozart_fetcher, :environment, Mix.env()
 
 import_config "#{Mix.env}.exs"

--- a/lib/mozart_fetcher/application.ex
+++ b/lib/mozart_fetcher/application.ex
@@ -18,7 +18,7 @@ defmodule MozartFetcher.Application do
       {ConCache, [name: :fetcher_cache, ttl_check_interval: :timer.seconds(1), global_ttl: :timer.seconds(30)]}
     ]
 
-    Application.put_env(:fetcher, :dev_cert_pem, System.get_env("DEV_CERT_PEM"))
+    Application.put_env(:mozart_fetcher, :dev_cert_pem, System.get_env("DEV_CERT_PEM"))
 
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options

--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -1,6 +1,6 @@
 defmodule HTTPClient do
   def get(endpoint) do
-    cert = Application.get_env(:fetcher, :dev_cert_pem)
+    cert = Application.get_env(:mozart_fetcher, :dev_cert_pem)
     headers = []
     options = [recv_timeout: 3000, ssl: [certfile: cert]]
 

--- a/lib/mozart_fetcher/local_cache.ex
+++ b/lib/mozart_fetcher/local_cache.ex
@@ -1,6 +1,6 @@
 defmodule MozartFetcher.LocalCache do
   def get_or_store(id, f) do
-    case Application.get_env(:fetcher, :environment) do
+    case Application.get_env(:mozart_fetcher, :environment) do
       :prod -> ConCache.get_or_store(:fetcher_cache, id, f)
       _ -> f.()
     end

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule MozartFetcher.MixProject do
 
   def project do
     [
-      app: :fetcher,
+      app: :mozart_fetcher,
       version: "0.1.0",
       elixir: "~> 1.6",
       start_permanent: Mix.env() == :prod,

--- a/rel/config.exs
+++ b/rel/config.exs
@@ -46,8 +46,8 @@ end
 # when running `mix release`, the first release in the file
 # will be used by default
 
-release :fetcher do
-  set version: current_version(:fetcher)
+release :mozart_fetcher do
+  set version: current_version(:mozart_fetcher)
   set applications: [
     :runtime_tools
   ]


### PR DESCRIPTION
~Branched off of https://github.com/bbc/mozart-fetcher/pull/7~

This PR finished renaming the app mozart_fetcher from fetcher. This prevents a mismatch between naming with mix releasing