### PR TITLE
Component error'ing broke Poison.decode

### DIFF
--- a/lib/mozart_fetcher/component.ex
+++ b/lib/mozart_fetcher/component.ex
@@ -16,10 +16,18 @@ defmodule MozartFetcher.Component do
   defp process(_config, {:error, %HTTPoison.Error{reason: reason}}) do
     ExMetrics.increment("error.component.process")
     Stump.log(:error, %{message: "Failed to process HTTP request, reason: #{reason}"})
-    {:error, reason}
+    failed_component(reason)
   end
 
   defp get(config) do
     LocalCache.get_or_store(config.endpoint, fn -> HTTPClient.get(config.endpoint) end)
+  end
+
+  defp failed_component(:timeout) do
+    %Component{index: 0, id: "", status: 408, envelope: %Envelope{}}
+  end
+
+  defp failed_component(_) do
+    %Component{index: 0, id: "", status: 500, envelope: %Envelope{}}
   end
 end

--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -24,13 +24,35 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns an error in case of timeout" do
+      expected = %MozartFetcher.Component{
+        envelope: %MozartFetcher.Envelope{
+          bodyInline: "",
+          bodyLast: [],
+          head: []
+        },
+        id: "",
+        index: 0,
+        status: 408
+      }
+
       config = %Config{endpoint: "http://localhost:8082/timeout"}
-      assert Component.fetch(config) == {:error, :timeout}
+      assert Component.fetch(config) == expected
     end
 
     test "it returns an error in case service is down" do
+      expected = %MozartFetcher.Component{
+        envelope: %MozartFetcher.Envelope{
+          bodyInline: "",
+          bodyLast: [],
+          head: []
+        },
+        id: "",
+        index: 0,
+        status: 500
+      }
+
       config = %Config{endpoint: "http://localhost:9090/fails"}
-      assert Component.fetch(config) == {:error, :econnrefused}
+      assert Component.fetch(config) == expected
     end
   end
 end


### PR DESCRIPTION
Due to the original return from the process method if there was a
failure it would cause the Poison.decode to kill the process for that request.
Handling it this way (similar to how Requester handles it) means that it
will still be able to parse a empty envelope while letting us know that
the component has timed out or there is a server error.