### PR TITLE
Validate http client

### DIFF
--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -9,7 +9,14 @@ defmodule HTTPClient do
       headers = []
       options = [recv_timeout: timeout, ssl: [certfile: cert]]
 
-      HTTPoison.get(endpoint, headers, options)
+      valid_response?(HTTPoison.get(endpoint, headers, options))
     end
   end
+
+  defp valid_response?(response = {:error, %HTTPoison.Error{reason: reason}}) do
+    Stump.log(:error, %{message: "HTTPoison Error", reason: reason})
+    response
+  end
+
+  defp valid_response?(response), do: response
 end

--- a/lib/mozart_fetcher/router.ex
+++ b/lib/mozart_fetcher/router.ex
@@ -5,11 +5,6 @@ defmodule MozartFetcher.Router do
   use ExMetrics
   plug(ExMetrics.Plug.PageMetrics)
 
-  use Plug.Debugger
-  require Logger
-
-  plug(Plug.Logger, log: :debug)
-
   plug(:match)
   plug(:dispatch)
 


### PR DESCRIPTION
Previously if there was an error with the HTTP Client we would just return the response regardless, this way we can at least log that there was an issue here.