### PR TITLE
RESFRAME-2729 - get cert paths for SSL requests

### DIFF
--- a/lib/mozart_fetcher.ex
+++ b/lib/mozart_fetcher.ex
@@ -21,8 +21,23 @@ defmodule MozartFetcher do
     Application.get_env(:mozart_fetcher, :max_connections)
   end
 
-  def cert do
-    System.get_env("DEV_CERT_PEM")
+  def request_ssl do
+    case environment() do
+      :prod -> [certfile: cert_path(), cacertfile: ca_cert_path(), keyfile: key_file_path()]
+      _ -> [certfile: System.get_env("DEV_CERT_PEM")]
+    end
+  end
+
+  defp cert_path do
+    System.get_env("cert_file_path")
+  end
+
+  defp ca_cert_path do
+    System.get_env("ca_file_path")
+  end
+
+  defp key_file_path do
+    System.get_env("key_file_path")
   end
 
   def environment do

--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -5,13 +5,11 @@ defmodule HTTPClient do
 
   def get(endpoint) do
     ExMetrics.timeframe "function.timing.http_client.get" do
-      cert = MozartFetcher.cert()
-
       headers = []
 
       options = [
         recv_timeout: @content_timeout,
-        ssl: [certfile: cert],
+        ssl: MozartFetcher.request_ssl(),
         hackney: [pool: :origin_pool]
       ]
 

--- a/test/mozart_fetcher_test.exs
+++ b/test/mozart_fetcher_test.exs
@@ -1,0 +1,33 @@
+defmodule MozartFetcherTest do
+  use ExUnit.Case
+
+  @fake_cert_file_path "<<cert_file_path>>"
+  @fake_ca_file_path "<<ca_file_path>>"
+  @fake_key_file_path "<<key_file_path>>"
+
+  test "request_ssl/0 on non-prod environment" do
+    assert [certfile: certfile] = MozartFetcher.request_ssl()
+    assert String.contains?(certfile, ".pem")
+  end
+
+  describe "on prod environment" do
+    setup do
+      System.put_env("cert_file_path", @fake_cert_file_path)
+      System.put_env("ca_file_path", @fake_ca_file_path)
+      System.put_env("key_file_path", @fake_key_file_path)
+      Application.put_env(:mozart_fetcher, :environment, :prod)
+
+      on_exit(fn ->
+        Application.put_env(:mozart_fetcher, :environment, :test)
+        System.put_env("cert_file_path", "")
+        System.put_env("ca_file_path", "")
+        System.put_env("key_file_path", "")
+      end)
+    end
+
+    test "request_ssl/0" do
+      assert [certfile: @fake_cert_file_path, cacertfile: @fake_ca_file_path, keyfile: @fake_key_file_path] ==
+               MozartFetcher.request_ssl()
+    end
+  end
+end


### PR DESCRIPTION
related but already merged PRs:
https://github.com/bbc/mozart-fetcher-build/pull/14
https://github.com/bbc/mozart-fetcher-build/pull/15

Tested by doing:
`cat james-debug-fetcher-config.json | curl -X POST -d @- http://localhost:8080/collect` with a config that hits internal bbc endpoints and gets a response