### PR TITLE
Add the format key to the config struct

### DIFF
--- a/lib/mozart_fetcher/config.ex
+++ b/lib/mozart_fetcher/config.ex
@@ -1,4 +1,4 @@
 defmodule MozartFetcher.Config do
   @derive Jason.Encoder
-  defstruct [:endpoint, :id, :must_succeed]
+  defstruct [:endpoint, :id, :must_succeed, :format]
 end

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -21,14 +21,25 @@ defmodule MozartFetcher.DecoderTest do
 
   describe "#list_to_struct_list" do
     test "when the list of JSON is successfuly decoded it is transformed into a list of structs" do
-      json =  ~s({ "components\": [{"id": "stream-icons", "endpoint": "localhost:8082/success", "must_succeed": true },
-                                  {"id": "weather-forecast", "endpoint": "localhost:8082/success", "must_succeed": false }
+      json =  ~s({ "components\": [
+                   {
+                     "id": "stream-icons",
+                     "endpoint": "localhost:8082/success",
+                     "must_succeed": true,
+                     "format": "envelope"
+                   },
+                   {
+                     "id": "weather-forecast",
+                     "endpoint": "localhost:8082/success",
+                     "must_succeed": false,
+                     "format": "envelope"
+                   }
                ]})
 
       expected = {
         :ok, [
-          %MozartFetcher.Config{endpoint: "localhost:8082/success", id: "stream-icons", must_succeed: true},
-          %MozartFetcher.Config{endpoint: "localhost:8082/success", id: "weather-forecast", must_succeed: false}
+          %MozartFetcher.Config{endpoint: "localhost:8082/success", id: "stream-icons", must_succeed: true, format: "envelope"},
+          %MozartFetcher.Config{endpoint: "localhost:8082/success", id: "weather-forecast", must_succeed: false, format: "envelope"}
         ]
        }
 

--- a/test/fixtures/payload1.json
+++ b/test/fixtures/payload1.json
@@ -2,6 +2,7 @@
     "components": [{
         "id": "stream-icons",
         "endpoint": "https://s3-eu-west-1.amazonaws.com/shared-application-buckets-public-1pmfwo80l61it/load-tests/static_envelopes/25082016/small-1.0.4.json",
-        "must_succeed": true
+        "must_succeed": true,
+        "format": "envelope"
     }]
 }

--- a/test/fixtures/payload_multiple_small.json
+++ b/test/fixtures/payload_multiple_small.json
@@ -3,47 +3,56 @@
         {
             "id": "small-1.0.0",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.0.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "small-1.0.1",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.1.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "small-1.0.2",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.2.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "small-1.0.3",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.3.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "small-1.0.4",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.4.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "small-1.0.5",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.5.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "bbc-morph-bbcdotcom-init",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/bbc-morph-bbcdotcom-init.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "morph-dna-comments-count",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/bbc-morph-dna-comments-count.json",
-            "must_succeed": true
+            "must_succeed": true,
+            "format": "envelope"
         },
         {
             "id": "empty",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/empty.json",
-            "must_succeed": false
+            "must_succeed": false,
+            "format": "envelope"
         }
     ]
 }

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -10,7 +10,8 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "stream-icons",
                         "endpoint": "localhost:8082/success",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         }]
                       }
                     )
@@ -46,7 +47,8 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "big-component",
                         "endpoint": "localhost:8082/big_component",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         }]
                       }
                     )
@@ -81,17 +83,20 @@ defmodule MozartFetcher.IntegrationTest do
       json_body = ~s({
         "components": [{ "id": "news-front-page",
                         "endpoint": "localhost:8082/success",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         },
                         {
                           "id": "weather-front-page",
                           "endpoint": "localhost:8082/success",
-                          "must_succeed": true
+                          "must_succeed": true,
+                          "format": "envelope"
                         },
                         {
                           "id": "weather-component",
                           "endpoint": "localhost:8082/big_component",
-                          "must_succeed": true
+                          "must_succeed": true,
+                          "format": "envelope"
                         }]
                       }
                     )
@@ -147,7 +152,8 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "news-front-page",
                         "endpoint": "localhost:8082/non_200_status/404",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         }]
                       }
                     )
@@ -183,7 +189,8 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "weather-front-page",
                         "endpoint": "localhost:8082/non_200_status/408",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         }]
                       }
                     )
@@ -219,7 +226,8 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "weather-front-page",
                         "endpoint": "localhost:8082/non_200_status/500",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         }]
                       }
                     )

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -36,7 +36,8 @@ defmodule MozartFetcher.RouterTest do
         "components": [{
                         "id": "stream-icons",
                         "endpoint": "localhost:8082/success",
-                        "must_succeed": true
+                        "must_succeed": true,
+                        "format": "envelope"
                         }]
                       }
                     )


### PR DESCRIPTION
In assembler we add the format key to the config to differentiate between envelope and ares type responses. Fetcher was not handling that and erroring when trying to fit the :format key into the %Config{} struct.

https://github.com/bbc/mozart-assembler/blob/4ecfea0484de71a25592debbda0fc679d9c5b42f/src/lib/mozart_assembler/processors/config_interpolator.rb#L31

https://github.com/bbc/mozart-assembler/blob/4aa7da18175426acaeb80922f858f4251d8e10a5/src/lib/mozart_assembler/renderers/ares.rb#L47