### PR TITLE
Encodes invalid URLs.

### DIFF
--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -13,7 +13,7 @@ defmodule HTTPClient do
         hackney: [pool: :origin_pool]
       ]
 
-      valid_response?(HTTPoison.get(endpoint, headers, options))
+      valid_response?(HTTPoison.get(URI.encode(endpoint), headers, options))
     end
   end
 

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -1,0 +1,15 @@
+defmodule HTTPClientTest do
+  use ExUnit.Case
+
+  describe "get" do
+    test "using a valid URL" do
+      {:ok, resp} = HTTPClient.get("http://localhost:8082/foo/bar")
+      assert resp.request_url == "http://localhost:8082/foo/bar"
+    end
+
+    test "using a URL containing white spaces" do
+      {:ok, resp} = HTTPClient.get("http://localhost:8082/foo bar")
+      assert resp.request_url == "http://localhost:8082/foo%20bar"
+    end
+  end
+end


### PR DESCRIPTION
To handle whitespace in paths