### PR TITLE
Second attempt at retrying failed requests

### DIFF
--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -26,5 +26,122 @@ defmodule HTTPClientTest do
       {:ok, resp} = HTTPClient.get("http://localhost:8082/foo bar?baz= true")
       assert resp.request_url == "http://localhost:8082/foo%20bar?baz=%20true"
     end
+
+    test "makes only one request on success" do
+      defmodule MockClientSuccessfulResponse do
+        def get(endpoint, _, _) do
+          {:ok,
+           %HTTPoison.Response{
+             request_url: "#{endpoint}/called"
+           }}
+        end
+      end
+
+      returned_response =
+        HTTPClient.get("http://localhost:8082/foo", MockClientSuccessfulResponse)
+
+      assert returned_response ==
+               {:ok, %HTTPoison.Response{request_url: "http://localhost:8082/foo/called"}}
+    end
+
+    test "makes request twice on connection closed and successful second time" do
+      defmodule MockClientClosedResponseSuccessfulSecondTime do
+        @responses [
+          {:error,
+           %HTTPoison.Error{
+             reason: :closed
+           }},
+          {:ok,
+           %HTTPoison.Response{
+             request_url: "http://localhost:8082/foo/called"
+           }}
+        ]
+
+        def start_link do
+          Agent.start_link(fn -> @responses end, name: __MODULE__)
+        end
+
+        def get(_, _, _) do
+          Agent.get_and_update(__MODULE__, fn responses -> List.pop_at(responses, 0) end)
+        end
+      end
+
+      MockClientClosedResponseSuccessfulSecondTime.start_link()
+
+      returned_response =
+        HTTPClient.get("http://localhost:8082/foo", MockClientClosedResponseSuccessfulSecondTime)
+
+      assert returned_response ==
+               {:ok, %HTTPoison.Response{request_url: "http://localhost:8082/foo/called"}}
+    end
+
+    test "makes request twice on connection closed and unsuccessful second time" do
+      defmodule MockClientClosedResponseUnsuccessfulSecondTime do
+        def get(_, _, _) do
+          {:error,
+           %HTTPoison.Error{
+             reason: :closed
+           }}
+        end
+      end
+
+      returned_response =
+        HTTPClient.get(
+          "http://localhost:8082/foo",
+          MockClientClosedResponseUnsuccessfulSecondTime
+        )
+
+      assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :closed}}
+    end
+
+    test "makes request twice on connection timeout and successful second time" do
+      defmodule MockClientTimeoutResponseSuccessfulSecondTime do
+        @responses [
+          {:error,
+           %HTTPoison.Error{
+             reason: :timeout
+           }},
+          {:ok,
+           %HTTPoison.Response{
+             request_url: "http://localhost:8082/foo/called"
+           }}
+        ]
+
+        def start_link do
+          Agent.start_link(fn -> @responses end, name: __MODULE__)
+        end
+
+        def get(_, _, _) do
+          Agent.get_and_update(__MODULE__, fn responses -> List.pop_at(responses, 0) end)
+        end
+      end
+
+      MockClientTimeoutResponseSuccessfulSecondTime.start_link()
+
+      returned_response =
+        HTTPClient.get("http://localhost:8082/foo", MockClientTimeoutResponseSuccessfulSecondTime)
+
+      assert returned_response ==
+               {:ok, %HTTPoison.Response{request_url: "http://localhost:8082/foo/called"}}
+    end
+
+    test "makes request twice on connection timeout and unsuccessful second time" do
+      defmodule MockClientTimeoutResponseUnsuccessfulSecondTime do
+        def get(_, _, _) do
+          {:error,
+           %HTTPoison.Error{
+             reason: :timeout
+           }}
+        end
+      end
+
+      returned_response =
+        HTTPClient.get(
+          "http://localhost:8082/foo",
+          MockClientTimeoutResponseUnsuccessfulSecondTime
+        )
+
+      assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
+    end
   end
 end


### PR DESCRIPTION
The http_client was split into making the request and retrying failed connections and any response parsing and logging was moved into a component_fetcher. Module name can be discussed.

Both of these were tested by adding a client parameter to allow for a mock client to be passed in. The issue with this is returning back different data, unsuccessful and then successful for the same requests. I had a few ideas around this, but best to keep this simple. This was in a different direction to using a mocking library as a functional language should allow for dependencies to be passed in.

Any ideas to simplify this are welcome.

https://jira.dev.bbc.co.uk/browse/RESFRAME-2754