### PR TITLE
Refine logging and remove timeout retry

### DIFF
--- a/config/metrics.exs
+++ b/config/metrics.exs
@@ -8,5 +8,6 @@ config :ex_metrics,
     "error.envelope.decode",
     "success.component.process",
     "error.empty_component_list",
-    "error.component.process"
+    "error.component.process",
+    "http.component.retry"
   ]

--- a/lib/mozart_fetcher/component.ex
+++ b/lib/mozart_fetcher/component.ex
@@ -67,7 +67,6 @@ defmodule MozartFetcher.Component do
   end
 
   defp metric(id, endpoint, status) when is_integer(status) do
-    ExMetrics.increment("error.component.process")
     ExMetrics.increment("error.component.process.#{id}")
     ExMetrics.increment("error.component.process.#{id}.#{status}")
     ExMetrics.increment("error.component.process.#{status}")

--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -15,6 +15,7 @@ defmodule HTTPClient do
 
       case make_request(sanitise(endpoint), headers, options, client) do
         {:error, %HTTPoison.Error{reason: :closed}} ->
+          ExMetrics.increment("http.component.retry")
           make_request(sanitise(endpoint), headers, options, client)
 
         {k, resp} ->

--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -13,11 +13,8 @@ defmodule HTTPClient do
         hackney: [pool: :origin_pool]
       ]
 
-      case log_errors_and_return(make_request(sanitise(endpoint), headers, options, client)) do
+      case make_request(sanitise(endpoint), headers, options, client) do
         {:error, %HTTPoison.Error{reason: :closed}} ->
-          make_request(sanitise(endpoint), headers, options, client)
-
-        {:error, %HTTPoison.Error{reason: :timeout}} ->
           make_request(sanitise(endpoint), headers, options, client)
 
         {k, resp} ->

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -93,55 +93,5 @@ defmodule HTTPClientTest do
 
       assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :closed}}
     end
-
-    test "makes request twice on connection timeout and successful second time" do
-      defmodule MockClientTimeoutResponseSuccessfulSecondTime do
-        @responses [
-          {:error,
-           %HTTPoison.Error{
-             reason: :timeout
-           }},
-          {:ok,
-           %HTTPoison.Response{
-             request_url: "http://localhost:8082/foo/called"
-           }}
-        ]
-
-        def start_link do
-          Agent.start_link(fn -> @responses end, name: __MODULE__)
-        end
-
-        def get(_, _, _) do
-          Agent.get_and_update(__MODULE__, fn responses -> List.pop_at(responses, 0) end)
-        end
-      end
-
-      MockClientTimeoutResponseSuccessfulSecondTime.start_link()
-
-      returned_response =
-        HTTPClient.get("http://localhost:8082/foo", MockClientTimeoutResponseSuccessfulSecondTime)
-
-      assert returned_response ==
-               {:ok, %HTTPoison.Response{request_url: "http://localhost:8082/foo/called"}}
-    end
-
-    test "makes request twice on connection timeout and unsuccessful second time" do
-      defmodule MockClientTimeoutResponseUnsuccessfulSecondTime do
-        def get(_, _, _) do
-          {:error,
-           %HTTPoison.Error{
-             reason: :timeout
-           }}
-        end
-      end
-
-      returned_response =
-        HTTPClient.get(
-          "http://localhost:8082/foo",
-          MockClientTimeoutResponseUnsuccessfulSecondTime
-        )
-
-      assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :timeout}}
-    end
   end
 end


### PR DESCRIPTION
Remove the first metric and logging for error as we retry. If the retry was in the library we wouldn't be logging this anyway.

Removes the timeout matcher so we only retry on connection closed.

https://jira.dev.bbc.co.uk/browse/RESFRAME-2754