### PR TITLE
Cache successul responses

### DIFF
--- a/lib/mozart_fetcher/application.ex
+++ b/lib/mozart_fetcher/application.ex
@@ -13,7 +13,7 @@ defmodule MozartFetcher.Application do
         plug: MozartFetcher.FakeOrigin,
         options: [port: 8082]
       ),
-      {ConCache, [name: :fetcher_test_cache, ttl_check_interval: false]}
+      {ConCache, [name: :fetcher_cache, ttl_check_interval: false]}
     ]
   end
 

--- a/lib/mozart_fetcher/local_cache.ex
+++ b/lib/mozart_fetcher/local_cache.ex
@@ -1,8 +1,8 @@
 defmodule MozartFetcher.LocalCache do
   def get_or_store(id, f) do
-    case MozartFetcher.environment() do
-      :prod -> ConCache.get_or_store(:fetcher_cache, id, f)
-      _ -> f.()
+    case f.() do
+      {:ok, resp} -> ConCache.get_or_store(:fetcher_cache, id, fn() -> {:ok, resp} end)
+      {:error, resp} -> {:error, resp}
     end
   end
 end

--- a/lib/mozart_fetcher/local_cache.ex
+++ b/lib/mozart_fetcher/local_cache.ex
@@ -1,8 +1,22 @@
 defmodule MozartFetcher.LocalCache do
-  def get_or_store(id, f) do
-    case f.() do
-      {:ok, resp} -> ConCache.get_or_store(:fetcher_cache, id, fn() -> {:ok, resp} end)
-      {:error, resp} -> {:error, resp}
+  def get_or_store(id, fun) do
+    ConCache.get(:fetcher_cache, id)
+    |> cond_fetch(id, fun)
+  end
+
+  defp cond_fetch(nil, id, fun) do
+    case fun.() do
+      resp = {:ok, %HTTPoison.Response{status_code: 200}} -> store(id, resp)
+      other -> other
     end
+  end
+
+  defp cond_fetch(value, _id, _fun) do
+    value
+  end
+
+  defp store(id, resp) do
+    ConCache.put(:fetcher_cache, id, resp)
+    resp
   end
 end

--- a/test/local_cache_test.exs
+++ b/test/local_cache_test.exs
@@ -1,0 +1,32 @@
+defmodule MozartFetcher.LocalCacheTest do
+  use ExUnit.Case
+
+  alias MozartFetcher.LocalCache
+  setup do
+    cache()
+    |> Enum.each(fn({key, _}) -> ConCache.delete(:fetcher_cache, key) end)
+    :ok
+  end
+
+  describe "a successful response" do
+    test "store the results in cache" do
+      f = fn () -> {:ok, "valid response"} end
+      LocalCache.get_or_store("abc", f)
+      assert cache() == [{"abc", {:ok, "valid response"}}]
+    end
+  end
+
+  describe "an error response" do
+    test "store the results in cache" do
+      f = fn () -> {:error, "NOT valid response"} end
+      LocalCache.get_or_store("abc", f)
+      assert cache() == []
+    end
+  end
+
+  defp cache() do
+    :fetcher_cache
+    |> ConCache.ets
+    |> :ets.tab2list
+  end
+end

--- a/test/local_cache_test.exs
+++ b/test/local_cache_test.exs
@@ -8,18 +8,33 @@ defmodule MozartFetcher.LocalCacheTest do
     :ok
   end
 
-  describe "a successful response" do
+  describe "a successful 200 response" do
     test "store the results in cache" do
-      f = fn () -> {:ok, "valid response"} end
-      LocalCache.get_or_store("abc", f)
-      assert cache() == [{"abc", {:ok, "valid response"}}]
+      response = {:ok, %HTTPoison.Response{status_code: 200, body: "valid response!"}}
+
+      f = fn () -> response end
+
+      assert LocalCache.get_or_store("abc", f) == response
+      assert cache() == [{"abc", response}]
+    end
+  end
+
+  describe "a successful 404 response" do
+    test "will NOT store the results in cache" do
+      response = {:ok, %HTTPoison.Response{status_code: 404, body: "not found :()"}}
+      f = fn () -> response end
+
+      assert LocalCache.get_or_store("abc", f) == response
+      assert cache() == []
     end
   end
 
   describe "an error response" do
     test "store the results in cache" do
-      f = fn () -> {:error, "NOT valid response"} end
-      LocalCache.get_or_store("abc", f)
+      response = {:error, %HTTPoison.Error{id: nil, reason: :econnrefused}}
+
+      f = fn () -> response end
+      assert LocalCache.get_or_store("abc", f) == response
       assert cache() == []
     end
   end


### PR DESCRIPTION
Uses and tests the cache layer on all environment (we could consider to remove it from dev/localdev in future if make sense...)

Only caches if http response is 200.