### PR TITLE
Add more time for task await and rename max_timeout to max

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,6 +30,7 @@ use Mix.Config
 config :mozart_fetcher,
   environment: Mix.env(),
   default_content_timeout: 3000,
+  additional_task_await_timeout: 50,
   default_connection_timeout: 500,
   max_connections: 5000
 

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -11,7 +11,7 @@ defmodule MozartFetcher.Fetcher do
 
   def process(components) do
     ExMetrics.timeframe "function.timing.fetcher.process" do
-      max_timeout = TimeoutParser.max_timeout(components)
+      max_timeout = TimeoutParser.max(components) + 100
 
       components
       |> Enum.with_index()

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -11,7 +11,9 @@ defmodule MozartFetcher.Fetcher do
 
   def process(components) do
     ExMetrics.timeframe "function.timing.fetcher.process" do
-      max_timeout = TimeoutParser.max(components) + 100
+      max_timeout =
+        TimeoutParser.max(components) +
+          Application.get_env(:mozart_fetcher, :additional_task_await_timeout)
 
       components
       |> Enum.with_index()

--- a/lib/mozart_fetcher/timeout_parser.ex
+++ b/lib/mozart_fetcher/timeout_parser.ex
@@ -6,7 +6,7 @@ defmodule MozartFetcher.TimeoutParser do
     query(uri.query)
   end
 
-  def max_timeout(components) do
+  def max(components) do
     components
     |> Enum.map(&Map.get(&1, :endpoint))
     |> Enum.map(fn endpoint -> parse(endpoint) end)

--- a/lib/mozart_fetcher/timeout_parser.ex
+++ b/lib/mozart_fetcher/timeout_parser.ex
@@ -8,9 +8,11 @@ defmodule MozartFetcher.TimeoutParser do
 
   def max(components) do
     components
-    |> Enum.map(&Map.get(&1, :endpoint))
-    |> Enum.map(fn endpoint -> parse(endpoint) end)
-    |> Enum.max()
+    |> Enum.reduce(@default_timeout, &component_timeout_or_current_timeout/2)
+  end
+
+  defp component_timeout_or_current_timeout(component, current_timeout) do
+    Enum.max([parse(component.endpoint), current_timeout])
   end
 
   defp query(nil) do

--- a/test/timeout_parser_test.exs
+++ b/test/timeout_parser_test.exs
@@ -52,7 +52,7 @@ defmodule MozartFetcher.TimeoutParserTest do
 
   describe "all components have timeouts" do
     test "it returns the maximum timeout" do
-      assert TimeoutParser.max_timeout([
+      assert TimeoutParser.max([
                %{endpoint: "http://origin.bbc.com/comp/a?timeout=3"},
                %{endpoint: "http://origin.bbc.com/comp/b?timeout=1"}
              ]) ==
@@ -62,7 +62,7 @@ defmodule MozartFetcher.TimeoutParserTest do
 
   describe "no components have timeouts" do
     test "it returns the maximum timeout" do
-      assert TimeoutParser.max_timeout([
+      assert TimeoutParser.max([
                %{endpoint: "http://origin.bbc.com/comp/a"},
                %{endpoint: "http://origin.bbc.com/comp/b"}
              ]) ==
@@ -72,7 +72,7 @@ defmodule MozartFetcher.TimeoutParserTest do
 
   describe "some components have timeouts" do
     test "it returns the maximum timeout" do
-      assert TimeoutParser.max_timeout([
+      assert TimeoutParser.max([
                %{endpoint: "http://origin.bbc.com/comp/a?timeout=5"},
                %{endpoint: "http://origin.bbc.com/comp/b"}
              ]) ==


### PR DESCRIPTION
Fetcher seems to return one or two 500s every few minutes. This PR allows the task waiting time to be slightly higher than the component fetching time to hopefully reduce the 500s. These 500s only started happening when changing the task await timeout to be the same as the component timeout. Previously this had a default of 5000.