### PR TITLE
Add error logging for errors and exceptions

### DIFF
--- a/lib/mozart_fetcher/timeout_parser.ex
+++ b/lib/mozart_fetcher/timeout_parser.ex
@@ -2,13 +2,25 @@ defmodule MozartFetcher.TimeoutParser do
   @default_timeout MozartFetcher.content_timeout()
 
   def parse(endpoint) do
-    uri = URI.parse(endpoint)
-    query(uri.query)
+    try do
+      uri = URI.parse(endpoint)
+      query(uri.query)
+    rescue
+      ex ->
+        Stump.log(:error, %{message: ex})
+        @default_timeout
+    end
   end
 
   def max(components) do
-    components
-    |> Enum.reduce(@default_timeout, &component_timeout_or_current_timeout/2)
+    try do
+      components
+      |> Enum.reduce(@default_timeout, &component_timeout_or_current_timeout/2)
+    rescue
+      ex ->
+        Stump.log(:error, %{message: ex})
+        @default_timeout
+    end
   end
 
   defp component_timeout_or_current_timeout(component, current_timeout) do

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -1,5 +1,5 @@
 defmodule MozartFetcher.FetcherTest do
-  alias MozartFetcher.{Fetcher}
+  alias MozartFetcher.{Fetcher, Config}
 
   use ExUnit.Case
 
@@ -7,5 +7,10 @@ defmodule MozartFetcher.FetcherTest do
 
   test "it returns an error id the component list is empy" do
     assert Fetcher.process([]) == {:error}
+  end
+
+  test "it gets success when passing component config" do
+    assert Fetcher.process([%Config{endpoint: "http://localhost:8082/foo", id: "foo"}]) ==
+             "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
   end
 end

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -100,5 +100,21 @@ defmodule HTTPClientTest do
 
       assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :closed}}
     end
+
+    test "catches exception" do
+      defmodule MockClientRaisesException do
+        def get(_, _, _) do
+          raise "Something went wrong!"
+        end
+      end
+
+      returned_response =
+        HTTPClient.get(
+          "http://localhost:8082/foo",
+          MockClientRaisesException
+        )
+
+      assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :unexpected}}
+    end
   end
 end

--- a/test/timeout_parser_test.exs
+++ b/test/timeout_parser_test.exs
@@ -50,6 +50,12 @@ defmodule MozartFetcher.TimeoutParserTest do
     end
   end
 
+  describe "when an exception is raised in parse" do
+    test "it returns the default timeout" do
+      assert TimeoutParser.parse(nil) == MozartFetcher.content_timeout()
+    end
+  end
+
   describe "all components have timeouts" do
     test "it returns the maximum timeout" do
       assert TimeoutParser.max([
@@ -77,6 +83,12 @@ defmodule MozartFetcher.TimeoutParserTest do
                %{endpoint: "http://origin.bbc.com/comp/b"}
              ]) ==
                5000
+    end
+  end
+
+  describe "when an exception is raised in max" do
+    test "it returns the default timeout" do
+      assert TimeoutParser.max(nil) == MozartFetcher.content_timeout()
     end
   end
 end


### PR DESCRIPTION
To understand why we get 500s from Fetcher since a change introduced the other day, a rescue has been used to be able to log if we get errors or exceptions.

It seems try/catch/rescue is not a pattern that should be used in this. But, to understand why we have 500s it seems rescue is used for unexpected situations and catch is used where there are expected failures.

If we get an exception raised this will have a message so I can do:
```ex
ex.message
```

If we get an error, then this won't have a message as this is likely to be a struct:
```ex
%FunctionClauseError{
 # properties of struct
}
```

For now I log the item as it is received. If this turns out to be an exception this can be made more specific. If it does not have the message property, then this would in turn raise an error.

I tried to log the stacktrace for the exception (before I made it generic) but I got this, so left that out for now:
```ex
Stump.log(:error, %{message: ex.message, stacktrace: System.stacktrace()})

** (Poison.EncodeError) unable to encode value: {ExUnit.Runner, :"-spawn_test_monitor/4-fun-1-", 4, [file: 'lib/ex_unit/runner.ex', line: 306]}
     code: HTTPClient.get(
     stacktrace:
       (poison) lib/poison/encoder.ex:383: Poison.Encoder.Any.encode/2
       (poison) lib/poison/encoder.ex:259: anonymous fn/3 in Poison.Encoder.List.encode/3
       (poison) lib/poison/encoder.ex:260: Poison.Encoder.List."-encode/3-lists^foldr/2-1-"/3
       (poison) lib/poison/encoder.ex:260: Poison.Encoder.List.encode/3
       (poison) lib/poison/encoder.ex:227: anonymous fn/4 in Poison.Encoder.Map.encode/3
       (poison) lib/poison/encoder.ex:228: Poison.Encoder.Map."-encode/3-lists^foldl/2-0-"/3
       (poison) lib/poison/encoder.ex:228: Poison.Encoder.Map.encode/3
       (poison) lib/poison.ex:41: Poison.encode!/2
       (stump) lib/stump.ex:28: Stump.log/2
       (mozart_fetcher) lib/mozart_fetcher/http_client.ex:30: HTTPClient.get/2
       test/http_client_test.exs:112: (test)
```