### PR TITLE
Increase additional await timeout

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,7 @@ use Mix.Config
 config :mozart_fetcher,
   environment: Mix.env(),
   default_content_timeout: 3000,
-  additional_task_await_timeout: 50,
+  additional_task_await_timeout: 100,
   default_connection_timeout: 500,
   max_connections: 5000
 


### PR DESCRIPTION
Still getting the timeout errors in the logs. Previously this was 5000ms as the default. Then we reduced it to 3050ms.

```ex
#PID<0.4665.2> running MozartFetcher.Router (connection #PID<0.4264.2>, stream id 2) terminated
Server: (http)
Request: POST /collect
** (exit) exited in: Task.await(%Task{owner: #PID<0.4665.2>, pid: #PID<0.4685.2>, ref: #Reference<0.948197304.1177288706.69862>}, 3050)
    ** (EXIT) time out
```

I am increasing the 50ms to 100ms as this might improve these timeouts if we were at a limit.