### PR TITLE
Use task stream

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -30,7 +30,6 @@ use Mix.Config
 config :mozart_fetcher,
   environment: Mix.env(),
   default_content_timeout: 3000,
-  additional_task_await_timeout: 100,
   default_connection_timeout: 500,
   max_connections: 5000
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -4,7 +4,7 @@ config :logger, level: :warn
 
 config :mozart_fetcher,
   default_content_timeout: 500,
-  default_connection_timeout: 20
+  default_connection_timeout: 50
 
 config :ex_metrics,
   send_metrics: false,

--- a/lib/mozart_fetcher/fake_origin.ex
+++ b/lib/mozart_fetcher/fake_origin.ex
@@ -52,7 +52,7 @@ defmodule MozartFetcher.FakeOrigin do
   end
 
   get "/timeout" do
-    :timer.sleep(3100)
+    :timer.sleep(10_000)
     send_resp(conn, 408, "timeout") # hide the "unused conn" warning message
   end
 

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -12,18 +12,18 @@ defmodule MozartFetcher.Fetcher do
     {:error}
   end
 
-  def process(components, buffer \\ @timeout_buffer) do
+  def process(configs, buffer \\ @timeout_buffer) do
     ExMetrics.timeframe "function.timing.fetcher.process" do
-      max_timeout = TimeoutParser.max(components) + buffer
+      max_timeout = TimeoutParser.max(configs) + buffer
 
       stream_opts = [timeout: max_timeout,
                      on_timeout: :kill_task,
                      max_concurrency: @max_concurrency]
 
-      components
+      configs
       |> Enum.with_index()
       |> Task.async_stream(&Component.fetch/1, stream_opts)
-      |> zip(components)
+      |> zip(configs)
       |> decorate_response()
       |> Jason.encode!()
     end

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -47,6 +47,7 @@ defmodule MozartFetcher.Fetcher do
                         reason: reason,
                         id: id})
 
-    %{envelope: %Envelope{}, id: id, index: nil, status: nil}
+    status = if reason == :timeout, do: 408, else: 500
+    %{envelope: %Envelope{}, id: id, index: nil, status: status}
   end
 end

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -12,11 +12,12 @@ defmodule MozartFetcher.Fetcher do
   def process(components) do
     ExMetrics.timeframe "function.timing.fetcher.process" do
       max_timeout = TimeoutParser.max(components)
+      stream_opts = [timeout: max_timeout, on_timeout: :kill_task, max_concurrency: 40]
 
       components
       |> Enum.with_index()
-      |> Task.async_stream(&Component.fetch/1, timeout: max_timeout,  on_timeout: :kill_task, max_concurrency: 40)
-      |> Enum.to_list
+      |> Task.async_stream(&Component.fetch/1, stream_opts)
+      |> Enum.to_list()
       |> extract_successful
       |> decorate_response
       |> Jason.encode!()
@@ -27,14 +28,18 @@ defmodule MozartFetcher.Fetcher do
     %{components: envelopes}
   end
 
+  # returns the successful one (including 500 etc) and logs
+  # the tasks which have not completed.
+  # At the moment it's in form  of `[exit: :timeout]` so hard to
+  # easily log which component has failed.
   defp extract_successful(components) do
     {oks, errors} = Enum.split_with(components, fn {k, _v} -> k == :ok end)
 
     errors |> Enum.each(&log(&1))
-    oks |> Enum.map(fn({:ok, result}) -> result end)
+    oks |> Enum.map(fn {:ok, result} -> result end)
   end
 
   defp log({type, error}) do
-    Stump.log(:error, %{message: "Component Process Error", type: type, error: error })
+    Stump.log(:error, %{message: "Component Process Error", type: type, error: error})
   end
 end

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -23,7 +23,6 @@ defmodule MozartFetcher.Fetcher do
       components
       |> Enum.with_index()
       |> Task.async_stream(&Component.fetch/1, stream_opts)
-      |> validate()
       |> zip(components)
       |> decorate_response()
       |> Jason.encode!()
@@ -34,13 +33,9 @@ defmodule MozartFetcher.Fetcher do
     %{components: envelopes}
   end
 
-  defp validate(responses) do
-    Enum.map(responses, &handle/1)
-  end
-
-  def zip(responses, configs) do
+  defp zip(responses, configs) do
     for {response, config} <- Enum.zip(responses, configs) do
-      Map.merge(response, %{id: config.id})
+      handle(response) |> Map.merge(%{id: config.id})
     end
   end
 

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -35,14 +35,18 @@ defmodule MozartFetcher.Fetcher do
 
   defp zip(responses, configs) do
     for {response, config} <- Enum.zip(responses, configs) do
-      handle(response) |> Map.merge(%{id: config.id})
+      handle(response, config.id)
     end
   end
 
-  defp handle({:ok, result}), do: result
+  defp handle({:ok, result}, _id), do: result
 
-  defp handle({state, reason}) do
-    Stump.log(:error, %{message: "Component Process Error", state: state, reason: reason})
-    %{envelope: %Envelope{}, id: nil, index: nil, status: nil}
+  defp handle({state, reason}, id) do
+    Stump.log(:error, %{message: "Component Process Error",
+                        state: state,
+                        reason: reason,
+                        id: id})
+
+    %{envelope: %Envelope{}, id: id, index: nil, status: nil}
   end
 end

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -18,8 +18,8 @@ defmodule MozartFetcher.Fetcher do
       |> Enum.with_index()
       |> Task.async_stream(&Component.fetch/1, stream_opts)
       |> Enum.to_list()
-      |> extract_successful
-      |> decorate_response
+      |> extract_successful()
+      |> decorate_response()
       |> Jason.encode!()
     end
   end
@@ -32,8 +32,8 @@ defmodule MozartFetcher.Fetcher do
   # the tasks which have not completed.
   # At the moment it's in form  of `[exit: :timeout]` so hard to
   # easily log which component has failed.
-  defp extract_successful(components) do
-    {oks, errors} = Enum.split_with(components, fn {k, _v} -> k == :ok end)
+  defp extract_successful(responses) do
+    {oks, errors} = Enum.split_with(responses, fn {k, _v} -> k == :ok end)
 
     errors |> Enum.each(&log(&1))
     oks |> Enum.map(fn {:ok, result} -> result end)

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -1,5 +1,5 @@
 defmodule MozartFetcher.Fetcher do
-  alias MozartFetcher.{Component, TimeoutParser}
+  alias MozartFetcher.{Component, TimeoutParser, Envelope}
 
   use ExMetrics
 
@@ -17,8 +17,7 @@ defmodule MozartFetcher.Fetcher do
       components
       |> Enum.with_index()
       |> Task.async_stream(&Component.fetch/1, stream_opts)
-      |> Enum.to_list()
-      |> extract_successful()
+      |> validate()
       |> decorate_response()
       |> Jason.encode!()
     end
@@ -28,18 +27,14 @@ defmodule MozartFetcher.Fetcher do
     %{components: envelopes}
   end
 
-  # returns the successful one (including 500 etc) and logs
-  # the tasks which have not completed.
-  # At the moment it's in form  of `[exit: :timeout]` so hard to
-  # easily log which component has failed.
-  defp extract_successful(responses) do
-    {oks, errors} = Enum.split_with(responses, fn {k, _v} -> k == :ok end)
-
-    errors |> Enum.each(&log(&1))
-    oks |> Enum.map(fn {:ok, result} -> result end)
+  defp validate(responses) do
+    Enum.map(responses, &handle/1)
   end
 
-  defp log({type, error}) do
-    Stump.log(:error, %{message: "Component Process Error", type: type, error: error})
+  defp handle({:ok, result}), do: result
+
+  defp handle({state, reason}) do
+    Stump.log(:error, %{message: "Component Process Error", state: state, reason: reason})
+    %Envelope{}
   end
 end

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -41,6 +41,6 @@ defmodule MozartFetcher.Fetcher do
 
   defp handle({state, reason}) do
     Stump.log(:error, %{message: "Component Process Error", state: state, reason: reason})
-    %Envelope{}
+    %{envelope: %Envelope{}, id: nil, index: nil, status: nil}
   end
 end

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -24,6 +24,7 @@ defmodule MozartFetcher.Fetcher do
       |> Enum.with_index()
       |> Task.async_stream(&Component.fetch/1, stream_opts)
       |> validate()
+      |> zip(components)
       |> decorate_response()
       |> Jason.encode!()
     end
@@ -35,6 +36,12 @@ defmodule MozartFetcher.Fetcher do
 
   defp validate(responses) do
     Enum.map(responses, &handle/1)
+  end
+
+  def zip(responses, configs) do
+    for {response, config} <- Enum.zip(responses, configs) do
+      Map.merge(response, %{id: config.id})
+    end
   end
 
   defp handle({:ok, result}), do: result

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -26,14 +26,14 @@ defmodule MozartFetcher.FetcherTest do
     assert Fetcher.process(config) == expected
   end
 
-  test "it returns empty envelopes for components erroring out with no generated response" do
+  test "it returns empty envelopes with status and id for components erroring out with no generated response" do
     config = [
       %Config{endpoint: "http://localhost:8082/foo", id: "foo"},
       %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}
     ]
 
     expected =
-      ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200},{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"timeout","index":null,"status":null}]})
+      ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200},{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"timeout","index":null,"status":408}]})
 
     assert Fetcher.process(config, 0) == expected
   end

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -33,7 +33,7 @@ defmodule MozartFetcher.FetcherTest do
     ]
 
     expected =
-      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]}]}"
+      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":null,\"index\":null,\"status\":null}]}"
 
     assert Fetcher.process(config, 0) == expected
   end

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -14,7 +14,7 @@ defmodule MozartFetcher.FetcherTest do
              "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
   end
 
-  test "it returns componet with don't exceed max async fetch timeout" do
+  test "it returns the components which don't exceed max async fetch timeout" do
     config = [
       %Config{endpoint: "http://localhost:8082/foo", id: "foo"},
       %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -14,14 +14,14 @@ defmodule MozartFetcher.FetcherTest do
              "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
   end
 
-  test "it returns the components which don't exceed max async fetch timeout" do
+  test "it returns the empty envelopes for components which exceed max async fetch timeout" do
     config = [
       %Config{endpoint: "http://localhost:8082/foo", id: "foo"},
       %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}
     ]
 
     expected =
-      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
+      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]}]}"
 
     assert Fetcher.process(config) == expected
   end

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -14,7 +14,19 @@ defmodule MozartFetcher.FetcherTest do
              "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
   end
 
-  test "it returns the empty envelopes for components which exceed max async fetch timeout" do
+  test "it returns envelopes for components timeout" do
+    config = [
+      %Config{endpoint: "http://localhost:8082/foo", id: "foo"},
+      %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}
+    ]
+
+    expected =
+      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"timeout\",\"index\":1,\"status\":408}]}"
+
+    assert Fetcher.process(config) == expected
+  end
+
+  test "it returns empty envelopes for components erroring out with no generated response" do
     config = [
       %Config{endpoint: "http://localhost:8082/foo", id: "foo"},
       %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}
@@ -23,6 +35,6 @@ defmodule MozartFetcher.FetcherTest do
     expected =
       "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]}]}"
 
-    assert Fetcher.process(config) == expected
+    assert Fetcher.process(config, 0) == expected
   end
 end

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -11,7 +11,7 @@ defmodule MozartFetcher.FetcherTest do
 
   test "it gets success when passing component config" do
     assert Fetcher.process([%Config{endpoint: "http://localhost:8082/foo", id: "foo"}]) ==
-             "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
+      ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200}]})
   end
 
   test "it returns envelopes for components timeout" do
@@ -21,7 +21,7 @@ defmodule MozartFetcher.FetcherTest do
     ]
 
     expected =
-      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"timeout\",\"index\":1,\"status\":408}]}"
+      ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200},{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"timeout","index":1,"status":408}]})
 
     assert Fetcher.process(config) == expected
   end
@@ -33,7 +33,7 @@ defmodule MozartFetcher.FetcherTest do
     ]
 
     expected =
-      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200},{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":null,\"index\":null,\"status\":null}]}"
+      ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200},{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"timeout","index":null,"status":null}]})
 
     assert Fetcher.process(config, 0) == expected
   end

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -15,8 +15,13 @@ defmodule MozartFetcher.FetcherTest do
   end
 
   test "it returns componet with don't exceed max async fetch timeout" do
-    config = [%Config{endpoint: "http://localhost:8082/foo", id: "foo"}, %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}]
-    expected = "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
+    config = [
+      %Config{endpoint: "http://localhost:8082/foo", id: "foo"},
+      %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}
+    ]
+
+    expected =
+      "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
 
     assert Fetcher.process(config) == expected
   end

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -13,4 +13,11 @@ defmodule MozartFetcher.FetcherTest do
     assert Fetcher.process([%Config{endpoint: "http://localhost:8082/foo", id: "foo"}]) ==
              "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
   end
+
+  test "it returns componet with don't exceed max async fetch timeout" do
+    config = [%Config{endpoint: "http://localhost:8082/foo", id: "foo"}, %Config{endpoint: "http://localhost:8082/timeout", id: "timeout"}]
+    expected = "{\"components\":[{\"envelope\":{\"bodyInline\":\"\",\"bodyLast\":[],\"head\":[]},\"id\":\"foo\",\"index\":0,\"status\":200}]}"
+
+    assert Fetcher.process(config) == expected
+  end
 end


### PR DESCRIPTION
This fixes two issues with the current components fetching approach.

1. starting multiple tasks with `Task.async/1` has all-or-nothing semantics. The crash of a single task takes down all other tasks.

2. `Task.async/1` links the new task to the starter process. Therefore, if any task process crashes, the starter process (`MozartFetcher.Router`) will crash too. This brings to errors like:
```elixir
Server: www-data.com:80 (http)
Request: POST /collect
** (exit) exited in: Task.await(%Task{owner: #PID<0.30047.0>, pid: #PID<0.30094.0>, ref: #Reference<0.3297827767.115605506.186927>}, 3100)
    ** (EXIT) time out
#PID<0.30580.0> running MozartFetcher.Router (connection #PID<0.26472.0>, stream id 36) terminated
Server: www-data.com:80 (http)
Request: POST /collect
** (exit) exited in: Task.await(%Task{owner: #PID<0.30580.0>, pid: #PID<0.30627.0>, ref: #Reference<0.3297827767.115605506.191539>}, 3100)
    ** (EXIT) time out
```

The new proposed approach uses [Task.async_stream](https://hexdocs.pm/elixir/Task.html#async_stream/3). On a first iteration, it doesn't fix the timeout issue, but at least the process is now supervised:

```elixir
defmodule Processor do
  def process(number) do
    :timer.sleep(6000)
  end
end

1..10
|> Task.async_stream(&Processor.process/1)
|> Enum.to_list()

(exit) exited in: Task.Supervised.stream(5000)
    ** (EXIT) time out
    (elixir) lib/task/supervised.ex:276: Task.Supervised.stream_reduce/7
    (elixir) lib/enum.ex:3015: Enum.reverse/1
    (elixir) lib/enum.ex:2649: Enum.to_list/1
```

The timeout is now easily fixable with:
```elixir
defmodule Processor do
  def process(number) do
    :timer.sleep(10000 - (number * 1000))
    number
  end
end

1..10
|> Task.async_stream(&Processor.process/1, on_timeout: :kill_task, max_concurrency: 40)
|> Enum.to_list()

[
  exit: :timeout,
  exit: :timeout,
  exit: :timeout,
  exit: :timeout,
  exit: :timeout,
  ok: 6,
  ok: 7,
  ok: 8,
  ok: 9,
  ok: 10
]
```