### PR TITLE
Add gzip header on request and uncompress response

### DIFF
--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -6,7 +6,7 @@ defmodule HTTPClient do
   def get(endpoint, client \\ client()) do
     try do
       ExMetrics.timeframe "function.timing.http_client.get" do
-        headers = []
+        headers = [{"accept-encoding", "gzip"}]
 
         options = [
           recv_timeout: TimeoutParser.parse(endpoint),
@@ -20,7 +20,7 @@ defmodule HTTPClient do
             make_request(sanitise(endpoint), headers, options, client)
 
           {k, resp} ->
-            {k, resp}
+            handle_response({k, resp})
         end
         |> log_errors_and_return()
       end
@@ -37,6 +37,40 @@ defmodule HTTPClient do
 
   defp make_request(endpoint, headers, options, client) do
     client.get(endpoint, headers, options)
+  end
+
+  defp handle_response({:ok, response}) do
+    {:ok,
+     %HTTPoison.Response{
+       headers: response.headers,
+       body:
+         decode_response_body(response.body, content_encoding(process_headers(response.headers))),
+       status_code: response.status_code
+     }}
+  end
+
+  defp handle_response(response), do: response
+
+  defp process_headers(headers) do
+    Enum.map(headers, fn {k, v} -> {String.downcase(k), v} end)
+  end
+
+  defp decode_response_body(body, "gzip"), do: :zlib.gunzip(body)
+  defp decode_response_body(body, "x-gzip"), do: :zlib.gunzip(body)
+  defp decode_response_body(body, _encoding), do: body
+
+  defp content_encoding(headers) do
+    case get_content_encoding(headers) do
+      {_, content_encoding} ->
+        content_encoding
+
+      nil ->
+        ""
+    end
+  end
+
+  defp get_content_encoding(headers) do
+    List.keyfind(headers, "content-encoding", 0)
   end
 
   defp log_errors_and_return(response = {:error, %HTTPoison.Error{reason: reason}}) do

--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -41,12 +41,11 @@ defmodule HTTPClient do
 
   defp handle_response({:ok, response}) do
     {:ok,
-     %HTTPoison.Response{
-       headers: response.headers,
-       body:
-         decode_response_body(response.body, content_encoding(process_headers(response.headers))),
-       status_code: response.status_code
-     }}
+     Map.put(
+       response,
+       :body,
+       decode_response_body(response.body, content_encoding(process_headers(response.headers)))
+     )}
   end
 
   defp handle_response(response), do: response

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -116,5 +116,30 @@ defmodule HTTPClientTest do
 
       assert returned_response == {:error, %HTTPoison.Error{id: nil, reason: :unexpected}}
     end
+
+    test "uncompresses a gzipped response" do
+      defmodule MockCompressedSuccessfulResponse do
+        def get(_, _, _) do
+          {:ok,
+           %HTTPoison.Response{
+             headers: [{"content-encoding", "gzip"}],
+             body: :zlib.gzip("Hello world!"),
+             status_code: 200
+           }}
+        end
+      end
+
+      returned_response =
+        HTTPClient.get("http://localhost:8082/foo", MockCompressedSuccessfulResponse)
+
+      assert returned_response ==
+               {:ok,
+                %HTTPoison.Response{
+                  body: "Hello world!",
+                  headers: [{"content-encoding", "gzip"}],
+                  request: nil,
+                  status_code: 200
+                }}
+    end
   end
 end


### PR DESCRIPTION
It seems other libraries (such as Go) automatically add an "accept-encoding" header when making requests and these uncompress the responses. This header means a server can respond with compressed content based on the value and will add a "content-encoding" header on the response for the client.

HTTPoison does not do this. There is an issue in Hackney open from 2015 to do this. For now, I have added a "gzip" header when making the requests and uncompress the response.

https://jira.dev.bbc.co.uk/browse/RESFRAME-2778