### PR TITLE
Log simple string and metric for when component fetching errors

### DIFF
--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -25,8 +25,9 @@ defmodule HTTPClient do
         |> log_errors_and_return()
       end
     rescue
-      ex ->
-        Stump.log(:error, %{message: ex})
+      _ ->
+        ExMetrics.increment("http.component.error")
+        Stump.log(:error, %{message: "HTTP Client error caught"})
         {:error, %HTTPoison.Error{reason: :unexpected}}
     end
   end


### PR DESCRIPTION
The exception wasn't able to be converted to JSON and produced an error when logging.

https://jira.dev.bbc.co.uk/browse/RESFRAME-2778