### PR TITLE
Remove data items from being logged as may not be valid JSON

### DIFF
--- a/lib/mozart_fetcher/decoder.ex
+++ b/lib/mozart_fetcher/decoder.ex
@@ -19,7 +19,7 @@ defmodule MozartFetcher.Decoder do
     case struct!(struct, map) do
       {:error} ->
         ExMetrics.increment("error.components.decode")
-        Stump.log(:error, %{message: "Invalid keys passed to to_struct", struct: struct, map: map})
+        Stump.log(:error, %{message: "Invalid keys passed to to_struct", map: map})
         {:error}
       struct -> struct
     end

--- a/lib/mozart_fetcher/envelope.ex
+++ b/lib/mozart_fetcher/envelope.ex
@@ -11,7 +11,7 @@ defmodule MozartFetcher.Envelope do
         envelope
       {:error}    ->
         ExMetrics.increment("error.envelope.decode")
-        Stump.log(:error, %{message: "Failed to decode Envelope", body: body})
+        Stump.log(:error, %{message: "Failed to decode Envelope"})
         %Envelope{}
     end
   end

--- a/lib/mozart_fetcher/router.ex
+++ b/lib/mozart_fetcher/router.ex
@@ -44,7 +44,7 @@ defmodule MozartFetcher.Router do
         {:ok, components}
       {:error}        ->
         ExMetrics.increment("error.components.decode")
-        Stump.log(:error, %{message: "Failed to decode components into list", body: body})
+        Stump.log(:error, %{message: "Failed to decode components into list"})
         {:error}
     end
   end


### PR DESCRIPTION
Still seeing lots of errors in the logs:
```
Task #PID<0.17523.16> started from #PID<0.17535.16> terminating
** (FunctionClauseError) no function clause matching in Poison.Encoder.BitString.chunk_size/3
    (poison) lib/poison/encoder.ex:139: Poison.Encoder.BitString.chunk_size(<<139, 8, 0, 0, 0, 0, 0, 0, 3, 236, 189, 137, 126, 219, 56, 178, 55, 250, 42, 180, 79, 143, 91, 28, 83, 138, 100, 59, 94, 164, 48, 154, 116, 58, 233, 206, 116, 156, 228, 180, 211, 61, 103, 198, 246, 248, 7, 81, 144, 68, ...>>, nil, 0)
    (poison) lib/poison/encoder.ex:134: Poison.Encoder.BitString.escape/2
    (poison) lib/poison/encoder.ex:101: Poison.Encoder.BitString.escape/2
    (poison) lib/poison/encoder.ex:88: Poison.Encoder.BitString.encode/2
    (poison) lib/poison/encoder.ex:227: anonymous fn/4 in Poison.Encoder.Map.encode/3
    (poison) lib/poison/encoder.ex:228: Poison.Encoder.Map."-encode/3-lists^foldl/2-0-"/3
    (poison) lib/poison/encoder.ex:228: Poison.Encoder.Map.encode/3
    (poison) lib/poison.ex:41: Poison.encode!/2
Function: &:erlang.apply/2
```

Removing cases where we log data responses as they may not be valid JSON as we don't uncompress the body.

https://jira.dev.bbc.co.uk/browse/RESFRAME-2778