### PR TITLE
RESFRAME 3032: invalid envelope format

### DIFF
--- a/lib/mozart_fetcher/component.ex
+++ b/lib/mozart_fetcher/component.ex
@@ -5,38 +5,63 @@ defmodule MozartFetcher.Component do
     process(component_index, config, get(config))
   end
 
-  defp process(component_index, config = %Config{format: "ares", endpoint: endpoint}, {:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
+  defp process(
+         component_index,
+         config = %Config{format: "ares", endpoint: endpoint},
+         {:ok, %HTTPoison.Response{status_code: 200, body: body}}
+       ) do
     case Jason.decode(body, keys: :atoms) do
       {:ok, data} ->
         metric(config.id, endpoint, 200)
         %{index: component_index, id: config.id, status: 200, data: data}
+
       {:error, _err} ->
         metric(config.id, endpoint, :json_decode_error)
         failed_component(component_index, :json_decode_error, config.id, :ares)
     end
   end
 
-  defp process(component_index, config = %Config{endpoint: endpoint}, {:ok, %HTTPoison.Response{status_code: 200, body: body}}) do
+  defp process(
+         component_index,
+         config = %Config{endpoint: endpoint},
+         {:ok, %HTTPoison.Response{status_code: 200, body: body}}
+       ) do
     metric(config.id, endpoint, 200)
     %{index: component_index, id: config.id, status: 200, envelope: Envelope.build(body)}
   end
 
-  defp process(component_index, config = %Config{format: "ares", endpoint: endpoint}, {:ok, %HTTPoison.Response{status_code: status_code}}) do
+  defp process(
+         component_index,
+         config = %Config{format: "ares", endpoint: endpoint},
+         {:ok, %HTTPoison.Response{status_code: status_code}}
+       ) do
     metric(config.id, endpoint, status_code)
     %{index: component_index, id: config.id, status: status_code, data: %{}}
   end
 
-  defp process(component_index, config = %Config{endpoint: endpoint}, {:ok, %HTTPoison.Response{status_code: status_code}}) do
+  defp process(
+         component_index,
+         config = %Config{endpoint: endpoint},
+         {:ok, %HTTPoison.Response{status_code: status_code}}
+       ) do
     metric(config.id, endpoint, status_code)
     %{index: component_index, id: config.id, status: status_code, envelope: %Envelope{}}
   end
 
-  defp process(component_index, config = %Config{format: "ares", endpoint: endpoint}, {:error, %HTTPoison.Error{reason: reason}}) do
+  defp process(
+         component_index,
+         config = %Config{format: "ares", endpoint: endpoint},
+         {:error, %HTTPoison.Error{reason: reason}}
+       ) do
     metric(config.id, endpoint, reason)
     failed_component(component_index, reason, config.id, :ares)
   end
 
-  defp process(component_index, config = %Config{endpoint: endpoint}, {:error, %HTTPoison.Error{reason: reason}}) do
+  defp process(
+         component_index,
+         config = %Config{endpoint: endpoint},
+         {:error, %HTTPoison.Error{reason: reason}}
+       ) do
     metric(config.id, endpoint, reason)
     failed_component(component_index, reason, config.id, :envelope)
   end
@@ -70,10 +95,13 @@ defmodule MozartFetcher.Component do
     ExMetrics.increment("error.component.process.#{id}")
     ExMetrics.increment("error.component.process.#{id}.#{status}")
     ExMetrics.increment("error.component.process.#{status}")
-    Stump.log(:error, %{message: "Non-200 response",
-                        status: status,
-                        component: id,
-                        endpoint: endpoint})
+
+    Stump.log(:error, %{
+      message: "Non-200 response",
+      status: status,
+      component: id,
+      endpoint: endpoint
+    })
   end
 
   defp metric(id, endpoint, reason) do
@@ -82,9 +110,11 @@ defmodule MozartFetcher.Component do
     ExMetrics.increment("error.component.process.#{reason}")
     ExMetrics.increment("error.component.process.#{id}.#{reason}")
 
-    Stump.log(:error, %{message: "Failed to process HTTP request",
-                        reason: reason,
-                        id: id,
-                        endpoint: endpoint})
+    Stump.log(:error, %{
+      message: "Failed to process HTTP request",
+      reason: reason,
+      id: id,
+      endpoint: endpoint
+    })
   end
 end

--- a/lib/mozart_fetcher/decoder.ex
+++ b/lib/mozart_fetcher/decoder.ex
@@ -28,9 +28,7 @@ defmodule MozartFetcher.Decoder do
   def to_struct(map, struct) do
     case Map.keys(Map.from_struct(struct)) |> Enum.all?(&Map.has_key?(map, &1)) do
       true ->
-        case struct(struct, map) do
-          struct -> {:ok, struct}
-        end
+        {:ok, struct(struct, map)}
 
       false ->
         ExMetrics.increment("error.components.decode")

--- a/lib/mozart_fetcher/decoder.ex
+++ b/lib/mozart_fetcher/decoder.ex
@@ -1,14 +1,10 @@
 defmodule MozartFetcher.Decoder do
   def data_to_struct(data, struct) do
-    case Jason.decode(data, keys: :atoms) do
-      {:ok, decoded} ->
-        case to_struct(decoded, struct) do
-          {:error, _} -> {:error}
-          struct -> {:ok, struct}
-        end
-
-      {:error, _} ->
-        {:error}
+    with {:ok, decoded} <- Jason.decode(data, keys: :atoms),
+         {:ok, struct} <- to_struct(decoded, struct) do
+      {:ok, struct}
+    else
+      _ -> {:error}
     end
   end
 
@@ -20,7 +16,7 @@ defmodule MozartFetcher.Decoder do
          Enum.map(data[:components], fn map ->
            case to_struct(map, struct) do
              {:error, _} -> {:error}
-             struct -> struct
+             {:ok, struct} -> struct
            end
          end)}
 
@@ -33,7 +29,7 @@ defmodule MozartFetcher.Decoder do
     case Map.keys(Map.from_struct(struct)) |> Enum.all?(&Map.has_key?(map, &1)) do
       true ->
         case struct(struct, map) do
-          struct -> struct
+          struct -> {:ok, struct}
         end
 
       false ->

--- a/lib/mozart_fetcher/envelope.ex
+++ b/lib/mozart_fetcher/envelope.ex
@@ -5,7 +5,7 @@ defmodule MozartFetcher.Envelope do
   defstruct head: [], bodyInline: "", bodyLast: []
 
   def build(body) do
-    case Decoder.data_to_struct(body, %Envelope{}) do
+    case Decoder.decode_envelope(body, %Envelope{}) do
       {:ok, envelope} ->
         ExMetrics.increment("success.envelope.decode")
         envelope

--- a/lib/mozart_fetcher/envelope.ex
+++ b/lib/mozart_fetcher/envelope.ex
@@ -9,7 +9,8 @@ defmodule MozartFetcher.Envelope do
       {:ok, envelope} ->
         ExMetrics.increment("success.envelope.decode")
         envelope
-      {:error}    ->
+
+      {:error} ->
         ExMetrics.increment("error.envelope.decode")
         Stump.log(:error, %{message: "Failed to decode Envelope"})
         %Envelope{}

--- a/lib/mozart_fetcher/fake_origin.ex
+++ b/lib/mozart_fetcher/fake_origin.ex
@@ -44,6 +44,7 @@ defmodule MozartFetcher.FakeOrigin do
 
   get "/non_200_status/:code" do
     {status_code, _} = Integer.parse(conn.path_params["code"])
+
     send_resp(
       conn,
       status_code,
@@ -53,7 +54,8 @@ defmodule MozartFetcher.FakeOrigin do
 
   get "/timeout" do
     :timer.sleep(10_000)
-    send_resp(conn, 408, "timeout") # hide the "unused conn" warning message
+    # hide the "unused conn" warning message
+    send_resp(conn, 408, "timeout")
   end
 
   get "/*catchall" do

--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -16,9 +16,11 @@ defmodule MozartFetcher.Fetcher do
     ExMetrics.timeframe "function.timing.fetcher.process" do
       max_timeout = TimeoutParser.max(configs) + buffer
 
-      stream_opts = [timeout: max_timeout,
-                     on_timeout: :kill_task,
-                     max_concurrency: @max_concurrency]
+      stream_opts = [
+        timeout: max_timeout,
+        on_timeout: :kill_task,
+        max_concurrency: @max_concurrency
+      ]
 
       configs
       |> Enum.with_index()
@@ -42,10 +44,7 @@ defmodule MozartFetcher.Fetcher do
   defp handle({:ok, result}, _id), do: result
 
   defp handle({state, reason}, id) do
-    Stump.log(:error, %{message: "Component Process Error",
-                        state: state,
-                        reason: reason,
-                        id: id})
+    Stump.log(:error, %{message: "Component Process Error", state: state, reason: reason, id: id})
 
     status = if reason == :timeout, do: 408, else: 500
     %{envelope: %Envelope{}, id: id, index: nil, status: status}

--- a/lib/mozart_fetcher/router.ex
+++ b/lib/mozart_fetcher/router.ex
@@ -22,6 +22,7 @@ defmodule MozartFetcher.Router do
 
   def send_response({:ok, components}, conn) do
     response = Fetcher.process(components)
+
     conn
     |> put_resp_content_type("application/json")
     |> send_resp(200, response)
@@ -42,7 +43,8 @@ defmodule MozartFetcher.Router do
       {:ok, components} ->
         ExMetrics.increment("success.components.decode")
         {:ok, components}
-      {:error}        ->
+
+      {:error} ->
         ExMetrics.increment("error.components.decode")
         Stump.log(:error, %{message: "Failed to decode components into list"})
         {:error}

--- a/lib/mozart_fetcher/router.ex
+++ b/lib/mozart_fetcher/router.ex
@@ -39,7 +39,7 @@ defmodule MozartFetcher.Router do
   end
 
   def config(body) do
-    case Decoder.list_to_struct_list(body, %Config{}) do
+    case Decoder.decode_config(body, %Config{}) do
       {:ok, components} ->
         ExMetrics.increment("success.components.decode")
         {:ok, components}

--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -24,7 +24,11 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns the raw json response body when requesting a successful ares component" do
-      config = %Config{endpoint: "http://localhost:8082/json_data", id: "article-data", format: "ares"}
+      config = %Config{
+        endpoint: "http://localhost:8082/json_data",
+        id: "article-data",
+        format: "ares"
+      }
 
       expected = %{
         data: %{
@@ -41,7 +45,10 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns empty envelope when 202" do
-      config = %Config{endpoint: "http://localhost:8082/non_200_status/202", id: "news_navigation"}
+      config = %Config{
+        endpoint: "http://localhost:8082/non_200_status/202",
+        id: "news_navigation"
+      }
 
       expected = %{
         envelope: %Envelope{},
@@ -54,7 +61,10 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns empty envelope when 404" do
-      config = %Config{endpoint: "http://localhost:8082/non_200_status/404", id: "weather-forecast"}
+      config = %Config{
+        endpoint: "http://localhost:8082/non_200_status/404",
+        id: "weather-forecast"
+      }
 
       expected = %{
         envelope: %Envelope{},
@@ -99,7 +109,11 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns an error when requesting an ares component but the data is not valid json" do
-      config = %Config{endpoint: "http://localhost:8082/invalid_json_data", id: "article-data", format: "ares"}
+      config = %Config{
+        endpoint: "http://localhost:8082/invalid_json_data",
+        id: "article-data",
+        format: "ares"
+      }
 
       expected = %{
         data: %{},
@@ -112,7 +126,11 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns an error when requesting an ares component but the data is not found" do
-      config = %Config{endpoint: "http://localhost:8082/non_200_status/404", id: "article-data", format: "ares"}
+      config = %Config{
+        endpoint: "http://localhost:8082/non_200_status/404",
+        id: "article-data",
+        format: "ares"
+      }
 
       expected = %{
         data: %{},
@@ -125,7 +143,11 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns an error when requesting an ares component but it times out timeout" do
-      config = %Config{endpoint: "http://localhost:8082/timeout", id: "article-data", format: "ares"}
+      config = %Config{
+        endpoint: "http://localhost:8082/timeout",
+        id: "article-data",
+        format: "ares"
+      }
 
       expected = %{
         data: %{},
@@ -138,7 +160,11 @@ defmodule MozartFetcher.ComponentTest do
     end
 
     test "it returns an error when requesting an ares componnet but the service is down" do
-      config = %Config{endpoint: "http://localhost:9090/fails", id: "article-data", format: "ares"}
+      config = %Config{
+        endpoint: "http://localhost:9090/fails",
+        id: "article-data",
+        format: "ares"
+      }
 
       expected = %{
         data: %{},

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -17,13 +17,13 @@ defmodule MozartFetcher.DecoderTest do
            bodyLast: []
          }}
 
-      assert Decoder.data_to_struct(json, %Envelope{}) == expected
+      assert Decoder.decode_envelope(json, %Envelope{}) == expected
     end
 
     test "when the JSON contains invalid keys we rescue and return an error" do
       json = ~s({"head":[],"bodyInLine":"<DIV id=\\"site-container\\">","bodyLast":[]})
 
-      assert Decoder.data_to_struct(json, %Envelope{}) == {:error}
+      assert Decoder.decode_envelope(json, %Envelope{}) == {:error}
     end
   end
 
@@ -62,7 +62,7 @@ defmodule MozartFetcher.DecoderTest do
         ]
       }
 
-      assert Decoder.list_to_struct_list(json, %Config{}) == expected
+      assert Decoder.decode_config(json, %Config{}) == expected
     end
 
     test "when a map in the list of JSON has an invalid key, the other components are still returned" do
@@ -94,14 +94,14 @@ defmodule MozartFetcher.DecoderTest do
         ]
       }
 
-      assert Decoder.list_to_struct_list(json, %Config{}) == expected
+      assert Decoder.decode_config(json, %Config{}) == expected
     end
   end
 
   describe "when the map keys do not match the struct" do
     test "it returns an error" do
       json = ~s( "components": [{:"Foo": "Bar" }])
-      assert Decoder.data_to_struct(json, %Config{}) == {:error}
+      assert Decoder.decode_config(json, %Config{}) == {:error}
     end
   end
 end

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -64,6 +64,38 @@ defmodule MozartFetcher.DecoderTest do
 
       assert Decoder.list_to_struct_list(json, %Config{}) == expected
     end
+
+    test "when a map in the list of JSON has an invalid key, the other components are still returned" do
+      json = ~s({ "components\": [
+                   {
+                     "od": "stream-icons",
+                     "endpoint": "localhost:8082/success",
+                     "must_succeed": true,
+                     "format": "envelope"
+                   },
+                   {
+                     "id": "weather-forecast",
+                     "endpoint": "localhost:8082/success",
+                     "must_succeed": false,
+                     "format": "envelope"
+                   }
+               ]})
+
+      expected = {
+        :ok,
+        [
+          {:error},
+          %MozartFetcher.Config{
+            endpoint: "localhost:8082/success",
+            id: "weather-forecast",
+            must_succeed: false,
+            format: "envelope"
+          }
+        ]
+      }
+
+      assert Decoder.list_to_struct_list(json, %Config{}) == expected
+    end
   end
 
   describe "when the map keys do not match the struct" do

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -9,19 +9,27 @@ defmodule MozartFetcher.DecoderTest do
     test "when the JSON is successfully decoded it is transformed into a struct" do
       json = ~s({"head":[],"bodyInline":"<DIV id=\\"site-container\\">","bodyLast":[]})
 
-      expected = {:ok, %Envelope{
-        head: [],
-        bodyInline: ~s(<DIV id="site-container">),
-        bodyLast: []
-      }}
+      expected =
+        {:ok,
+         %Envelope{
+           head: [],
+           bodyInline: ~s(<DIV id="site-container">),
+           bodyLast: []
+         }}
 
       assert Decoder.data_to_struct(json, %Envelope{}) == expected
+    end
+
+    test "when the JSON contains invalid keys we rescue and return an error" do
+      json = ~s({"head":[],"bodyInLine":"<DIV id=\\"site-container\\">","bodyLast":[]})
+
+      assert Decoder.data_to_struct(json, %Envelope{}) == {:error}
     end
   end
 
   describe "#list_to_struct_list" do
     test "when the list of JSON is successfuly decoded it is transformed into a list of structs" do
-      json =  ~s({ "components\": [
+      json = ~s({ "components\": [
                    {
                      "id": "stream-icons",
                      "endpoint": "localhost:8082/success",
@@ -37,11 +45,22 @@ defmodule MozartFetcher.DecoderTest do
                ]})
 
       expected = {
-        :ok, [
-          %MozartFetcher.Config{endpoint: "localhost:8082/success", id: "stream-icons", must_succeed: true, format: "envelope"},
-          %MozartFetcher.Config{endpoint: "localhost:8082/success", id: "weather-forecast", must_succeed: false, format: "envelope"}
+        :ok,
+        [
+          %MozartFetcher.Config{
+            endpoint: "localhost:8082/success",
+            id: "stream-icons",
+            must_succeed: true,
+            format: "envelope"
+          },
+          %MozartFetcher.Config{
+            endpoint: "localhost:8082/success",
+            id: "weather-forecast",
+            must_succeed: false,
+            format: "envelope"
+          }
         ]
-       }
+      }
 
       assert Decoder.list_to_struct_list(json, %Config{}) == expected
     end

--- a/test/envelope_test.exs
+++ b/test/envelope_test.exs
@@ -16,6 +16,12 @@ defmodule MozartFetcher.EnvelopeTest do
              }
     end
 
+    test "it returns an error if the json contains an invalid key" do
+      component = ~s({"head":[],"bodyInLine":"<DIV id=\\"site-container\\">","bodyLast":[]})
+
+      assert Envelope.build(component) == %Envelope{}
+    end
+
     test "it returns an empty Envelope if not valid content" do
       component = "{"
       assert Envelope.build(component) == %Envelope{}

--- a/test/fetcher_test.exs
+++ b/test/fetcher_test.exs
@@ -11,7 +11,7 @@ defmodule MozartFetcher.FetcherTest do
 
   test "it gets success when passing component config" do
     assert Fetcher.process([%Config{endpoint: "http://localhost:8082/foo", id: "foo"}]) ==
-      ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200}]})
+             ~s({"components":[{"envelope":{"bodyInline":"","bodyLast":[],"head":[]},"id":"foo","index":0,"status":200}]})
   end
 
   test "it returns envelopes for components timeout" do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -65,7 +65,8 @@ defmodule MozartFetcher.IntegrationTest do
               envelope: %{
                 head: [],
                 bodyLast: [],
-                bodyInline: "<DIV id=\"big-component\" class=\"big\"><h1>This is a really big component</h1></DIV>"
+                bodyInline:
+                  "<DIV id=\"big-component\" class=\"big\"><h1>This is a really big component</h1></DIV>"
               }
             }
           ]
@@ -133,7 +134,8 @@ defmodule MozartFetcher.IntegrationTest do
               envelope: %{
                 head: [],
                 bodyLast: [],
-                bodyInline: "<DIV id=\"big-component\" class=\"big\"><h1>This is a really big component</h1></DIV>"
+                bodyInline:
+                  "<DIV id=\"big-component\" class=\"big\"><h1>This is a really big component</h1></DIV>"
               }
             }
           ]

--- a/test/local_cache_test.exs
+++ b/test/local_cache_test.exs
@@ -2,9 +2,11 @@ defmodule MozartFetcher.LocalCacheTest do
   use ExUnit.Case
 
   alias MozartFetcher.LocalCache
+
   setup do
     cache()
-    |> Enum.each(fn({key, _}) -> ConCache.delete(:fetcher_cache, key) end)
+    |> Enum.each(fn {key, _} -> ConCache.delete(:fetcher_cache, key) end)
+
     :ok
   end
 
@@ -12,7 +14,7 @@ defmodule MozartFetcher.LocalCacheTest do
     test "store the results in cache" do
       response = {:ok, %HTTPoison.Response{status_code: 200, body: "valid response!"}}
 
-      f = fn () -> response end
+      f = fn -> response end
 
       assert LocalCache.get_or_store("abc", f) == response
       assert cache() == [{"abc", response}]
@@ -22,7 +24,7 @@ defmodule MozartFetcher.LocalCacheTest do
   describe "a successful 404 response" do
     test "will NOT store the results in cache" do
       response = {:ok, %HTTPoison.Response{status_code: 404, body: "not found :()"}}
-      f = fn () -> response end
+      f = fn -> response end
 
       assert LocalCache.get_or_store("abc", f) == response
       assert cache() == []
@@ -33,7 +35,7 @@ defmodule MozartFetcher.LocalCacheTest do
     test "store the results in cache" do
       response = {:error, %HTTPoison.Error{id: nil, reason: :econnrefused}}
 
-      f = fn () -> response end
+      f = fn -> response end
       assert LocalCache.get_or_store("abc", f) == response
       assert cache() == []
     end
@@ -41,7 +43,7 @@ defmodule MozartFetcher.LocalCacheTest do
 
   defp cache() do
     :fetcher_cache
-    |> ConCache.ets
-    |> :ets.tab2list
+    |> ConCache.ets()
+    |> :ets.tab2list()
   end
 end

--- a/test/mozart_fetcher_test.exs
+++ b/test/mozart_fetcher_test.exs
@@ -26,7 +26,11 @@ defmodule MozartFetcherTest do
     end
 
     test "request_ssl/0" do
-      assert [certfile: @fake_cert_file_path, cacertfile: @fake_ca_file_path, keyfile: @fake_key_file_path] ==
+      assert [
+               certfile: @fake_cert_file_path,
+               cacertfile: @fake_ca_file_path,
+               keyfile: @fake_key_file_path
+             ] ==
                MozartFetcher.request_ssl()
     end
   end


### PR DESCRIPTION
This PR ensures that we do not raise a KeyError when trying to convert a map into a struct instead we check for the key before the conversion and handle accordingly.

Also contains some formatting of the rest of the project