### PR TITLE
RESFRAME-2740 - Remove all ares specific handling from fetcher

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,7 +36,7 @@ node {
   stage('Checkout mozart-fetcher-build') {
     sh 'mkdir -p mozart-fetcher-build'
     dir('mozart-fetcher-build') {
-      git url: 'https://github.com/bbc/mozart-fetcher-build', credentialsId: 'github', branch: 'master'
+      git url: 'https://github.com/bbc/mozart-fetcher-build', credentialsId: 'de1d9453-493a-4f18-a2ab-507822b96188', branch: 'master'
     }
   }
 

--- a/lib/mozart_fetcher/config.ex
+++ b/lib/mozart_fetcher/config.ex
@@ -1,4 +1,4 @@
 defmodule MozartFetcher.Config do
   @derive Jason.Encoder
-  defstruct [:endpoint, :id, :must_succeed, :format]
+  defstruct [:endpoint, :id, :must_succeed]
 end

--- a/lib/mozart_fetcher/decoder.ex
+++ b/lib/mozart_fetcher/decoder.ex
@@ -1,5 +1,5 @@
 defmodule MozartFetcher.Decoder do
-  alias MozartFetcher.{Envelope, Config}
+  alias MozartFetcher.Envelope
 
   def decode_envelope(data, struct) do
     case Jason.decode(data, keys: :atoms) do

--- a/test/component_test.exs
+++ b/test/component_test.exs
@@ -23,27 +23,6 @@ defmodule MozartFetcher.ComponentTest do
       assert Component.fetch({config, 0}) == expected
     end
 
-    test "it returns the raw json response body when requesting a successful ares component" do
-      config = %Config{
-        endpoint: "http://localhost:8082/json_data",
-        id: "article-data",
-        format: "ares"
-      }
-
-      expected = %{
-        data: %{
-          content: %{
-            some: "json data"
-          }
-        },
-        id: "article-data",
-        index: 0,
-        status: 200
-      }
-
-      assert Component.fetch({config, 0}) == expected
-    end
-
     test "it returns empty envelope when 202" do
       config = %Config{
         endpoint: "http://localhost:8082/non_200_status/202",
@@ -105,74 +84,6 @@ defmodule MozartFetcher.ComponentTest do
       }
 
       config = %Config{endpoint: "http://localhost:9090/fails", id: "news-top-stories"}
-      assert Component.fetch({config, 0}) == expected
-    end
-
-    test "it returns an error when requesting an ares component but the data is not valid json" do
-      config = %Config{
-        endpoint: "http://localhost:8082/invalid_json_data",
-        id: "article-data",
-        format: "ares"
-      }
-
-      expected = %{
-        data: %{},
-        id: "article-data",
-        index: 0,
-        status: 500
-      }
-
-      assert Component.fetch({config, 0}) == expected
-    end
-
-    test "it returns an error when requesting an ares component but the data is not found" do
-      config = %Config{
-        endpoint: "http://localhost:8082/non_200_status/404",
-        id: "article-data",
-        format: "ares"
-      }
-
-      expected = %{
-        data: %{},
-        id: "article-data",
-        index: 0,
-        status: 404
-      }
-
-      assert Component.fetch({config, 0}) == expected
-    end
-
-    test "it returns an error when requesting an ares component but it times out timeout" do
-      config = %Config{
-        endpoint: "http://localhost:8082/timeout",
-        id: "article-data",
-        format: "ares"
-      }
-
-      expected = %{
-        data: %{},
-        id: "article-data",
-        index: 0,
-        status: 408
-      }
-
-      assert Component.fetch({config, 0}) == expected
-    end
-
-    test "it returns an error when requesting an ares componnet but the service is down" do
-      config = %Config{
-        endpoint: "http://localhost:9090/fails",
-        id: "article-data",
-        format: "ares"
-      }
-
-      expected = %{
-        data: %{},
-        id: "article-data",
-        index: 0,
-        status: 500
-      }
-
       assert Component.fetch({config, 0}) == expected
     end
   end

--- a/test/decoder_test.exs
+++ b/test/decoder_test.exs
@@ -33,14 +33,12 @@ defmodule MozartFetcher.DecoderTest do
                    {
                      "id": "stream-icons",
                      "endpoint": "localhost:8082/success",
-                     "must_succeed": true,
-                     "format": "envelope"
+                     "must_succeed": true
                    },
                    {
                      "id": "weather-forecast",
                      "endpoint": "localhost:8082/success",
-                     "must_succeed": false,
-                     "format": "envelope"
+                     "must_succeed": false
                    }
                ]})
 
@@ -50,14 +48,12 @@ defmodule MozartFetcher.DecoderTest do
           %MozartFetcher.Config{
             endpoint: "localhost:8082/success",
             id: "stream-icons",
-            must_succeed: true,
-            format: "envelope"
+            must_succeed: true
           },
           %MozartFetcher.Config{
             endpoint: "localhost:8082/success",
             id: "weather-forecast",
-            must_succeed: false,
-            format: "envelope"
+            must_succeed: false
           }
         ]
       }

--- a/test/fixtures/payload1.json
+++ b/test/fixtures/payload1.json
@@ -2,7 +2,6 @@
     "components": [{
         "id": "stream-icons",
         "endpoint": "https://s3-eu-west-1.amazonaws.com/shared-application-buckets-public-1pmfwo80l61it/load-tests/static_envelopes/25082016/small-1.0.4.json",
-        "must_succeed": true,
-        "format": "envelope"
+        "must_succeed": true
     }]
 }

--- a/test/fixtures/payload_multiple_small.json
+++ b/test/fixtures/payload_multiple_small.json
@@ -3,56 +3,47 @@
         {
             "id": "small-1.0.0",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.0.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "small-1.0.1",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.1.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "small-1.0.2",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.2.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "small-1.0.3",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.3.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "small-1.0.4",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.4.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "small-1.0.5",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/small-1.0.5.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "bbc-morph-bbcdotcom-init",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/bbc-morph-bbcdotcom-init.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "morph-dna-comments-count",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/bbc-morph-dna-comments-count.json",
-            "must_succeed": true,
-            "format": "envelope"
+            "must_succeed": true
         },
         {
             "id": "empty",
             "endpoint": "http://news.test.files.bbci.co.uk/mozart/load_tests/25082016/empty.json",
-            "must_succeed": false,
-            "format": "envelope"
+            "must_succeed": false
         }
     ]
 }

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -10,8 +10,7 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "stream-icons",
                         "endpoint": "localhost:8082/success",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         }]
                       }
                     )
@@ -47,8 +46,7 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "big-component",
                         "endpoint": "localhost:8082/big_component",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         }]
                       }
                     )
@@ -84,20 +82,17 @@ defmodule MozartFetcher.IntegrationTest do
       json_body = ~s({
         "components": [{ "id": "news-front-page",
                         "endpoint": "localhost:8082/success",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         },
                         {
                           "id": "weather-front-page",
                           "endpoint": "localhost:8082/success",
-                          "must_succeed": true,
-                          "format": "envelope"
+                          "must_succeed": true
                         },
                         {
                           "id": "weather-component",
                           "endpoint": "localhost:8082/big_component",
-                          "must_succeed": true,
-                          "format": "envelope"
+                          "must_succeed": true
                         }]
                       }
                     )
@@ -154,8 +149,7 @@ defmodule MozartFetcher.IntegrationTest do
                         {
                           "id": "weather-component",
                           "endpoint": "localhost:8082/big_component",
-                          "must_succeed": true,
-                          "format": "envelope"
+                          "must_succeed": true
                         }]
                       }
                     )
@@ -175,8 +169,7 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "news-front-page",
                         "endpoint": "localhost:8082/non_200_status/404",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         }]
                       }
                     )
@@ -212,8 +205,7 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "weather-front-page",
                         "endpoint": "localhost:8082/non_200_status/408",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         }]
                       }
                     )
@@ -249,8 +241,7 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "id": "weather-front-page",
                         "endpoint": "localhost:8082/non_200_status/500",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         }]
                       }
                     )

--- a/test/router_test.exs
+++ b/test/router_test.exs
@@ -45,8 +45,7 @@ defmodule MozartFetcher.RouterTest do
         "components": [{
                         "id": "stream-icons",
                         "endpoint": "localhost:8082/success",
-                        "must_succeed": true,
-                        "format": "envelope"
+                        "must_succeed": true
                         }]
                       }
                     )
@@ -64,41 +63,6 @@ defmodule MozartFetcher.RouterTest do
                 head: [],
                 bodyLast: [],
                 bodyInline: "<DIV id=\"site-container\">"
-              }
-            }
-          ]
-        })
-
-      assert conn.state == :sent
-      assert conn.status == 200
-      assert get_resp_header(conn, "content-type") == ["application/json; charset=utf-8"]
-      assert conn.resp_body == expected_body
-    end
-
-    test "When requesting an ares data component (non-envelope) it returns the raw data in the response" do
-      json_body = ~s({
-        "components": [{
-                        "id": "article_data",
-                        "endpoint": "localhost:8082/json_data",
-                        "must_succeed": true,
-                        "format": "ares"
-                        }]
-                      }
-                    )
-      conn = conn(:post, "/collect", json_body)
-      conn = Router.call(conn, @opts)
-
-      expected_body =
-        Jason.encode!(%{
-          components: [
-            %{
-              status: 200,
-              index: 0,
-              id: "article_data",
-              data: %{
-                content: %{
-                  some: "json data"
-                }
               }
             }
           ]


### PR DESCRIPTION
After https://github.com/bbc/mozart-assembler/pull/355 was merged the Assembler goes directly to Ares for JSON data, so the fetcher no longer needs specific Ares handling logic. 

#61 has been closed in favour of this PR, as there is now no need to bring the envelope and ares handling inline as the fetcher no longer needs to deal with Ares requests.