### PR TITLE
Update and use to V2 of cfn-signal

### DIFF
--- a/SOURCES/component-status-cfn-signal.sh
+++ b/SOURCES/component-status-cfn-signal.sh
@@ -2,9 +2,12 @@
 
 COMPONENT_NAME=$(cat /etc/bake-scripts/config.json | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["name"]')
 ENVIRONMENT=$(cat /etc/bake-scripts/config.json | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["environment"]')
+REGION=$(cat /etc/bake-scripts/config.json | python -c 'import json,sys;obj=json.load(sys.stdin);print obj["configuration"]["aws_region"]')
 
 # STACKID should be changed to evaluate to the name of your Main stack
 STACKID=${ENVIRONMENT}-${COMPONENT_NAME}-main
+
+sudo easy_install-3.6 https://dev-mozart-rpms.s3.eu-west-1.amazonaws.com/aws-cfn-bootstrap-py3-2.0-19.tar.gz
 
 # beginning of app testing loop
 # edit the contents of the next two lines to define a specific test for your application
@@ -15,5 +18,5 @@ done
 # end of app testing loop
 
 # We should only reach here if the check above has confirmed that the app is up
-# resource_id should be set to the Logical Resource id of the instances AutoScalingGroup
-/usr/local/cfn-signal/bin/signal --resource_id "ApplicationAutoScalingGroup" --stack_name "${STACKID}" --status "SUCCESS"
+# resource should be set to the Logical Resource id of the instances AutoScalingGroup
+/usr/local/bin/cfn-signal --stack="${STACKID}" --region="${REGION}" --resource="ComponentAutoScalingGroup" --success=true

--- a/mozart-fetcher.spec
+++ b/mozart-fetcher.spec
@@ -20,7 +20,6 @@ Requires: cosmos-ca-chains cosmos-ca-tools
 Requires: bbc-statsd-cloudwatch
 Requires: amazon-cloudwatch-agent
 Requires: component-logger
-Requires: cfn-signal
 
 %description
 mozart-fetcher is a service for fetching multiple components


### PR DESCRIPTION
This PR updates the CFN Signal package to v2 as it was not working with metadata v2 options we were introducing with this PR: https://github.com/bbc/frameworks-infra/pull/181