### PR TITLE
Use ApplicationAutoScalingGroup instead of Component for signal script

### DIFF
--- a/SOURCES/component-status-cfn-signal.sh
+++ b/SOURCES/component-status-cfn-signal.sh
@@ -19,4 +19,4 @@ done
 
 # We should only reach here if the check above has confirmed that the app is up
 # resource should be set to the Logical Resource id of the instances AutoScalingGroup
-/usr/local/bin/cfn-signal --stack="${STACKID}" --region="${REGION}" --resource="ComponentAutoScalingGroup" --success=true
+/usr/local/bin/cfn-signal --stack="${STACKID}" --region="${REGION}" --resource="ApplicationAutoScalingGroup" --success=true


### PR DESCRIPTION
Fix for https://github.com/bbc/mozart-fetcher/pull/68 as Fetcher uses ApplicationAutoScalingGroup not ComponentAutoScalingGroup.
As can be seen here: https://github.com/bbc/frameworks-infra/blob/master/mozart/mozart-fetcher/stacks/main.json#L404