### PR TITLE
Use ettomatic/elixir-centos image instead of quintix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM qixxit/elixir-centos
+FROM ettomatic/elixir-centos
 
 MAINTAINER Ettore Berardi <ettore.berardi@bbc.co.uk>
 MAINTAINER Sam French <Sam.French@bbc.co.uk>


### PR DESCRIPTION
This will allow us more control over the versioning of the local image.