### PR TITLE
Use aws-cfn-bootstrap rpm

### DIFF
--- a/SOURCES/component-status-cfn-signal.sh
+++ b/SOURCES/component-status-cfn-signal.sh
@@ -7,8 +7,6 @@ REGION=$(cat /etc/bake-scripts/config.json | python3 -c 'import json,sys;obj=jso
 # STACKID should be changed to evaluate to the name of your Main stack
 STACKID=${ENVIRONMENT}-${COMPONENT_NAME}-main
 
-sudo easy_install-3.6 https://dev-mozart-rpms.s3.eu-west-1.amazonaws.com/aws-cfn-bootstrap-py3-2.0-19.tar.gz
-
 # beginning of app testing loop
 # edit the contents of the next two lines to define a specific test for your application
 until [ "$status" == "200" ]; do

--- a/mozart-fetcher.spec
+++ b/mozart-fetcher.spec
@@ -18,6 +18,7 @@ BuildArch: x86_64
 
 Requires: amazon-cloudwatch-agent
 Requires: component-logger
+Requires: aws-cfn-bootstrap
 
 %description
 mozart-fetcher is a service for fetching multiple components


### PR DESCRIPTION
This PR adds the "aws-cfn-bootstrap" rpm as a dependency to be able to use the "cfn-signal" script when the instance appears and the application starts. This installs it at bake time so will be on the AMI when it is snapshotted and available to any instance created from the AMI.

The original PR was for another Mozart application.
