### PR TITLE
RESFRAME 5444 codebuild warnings

### DIFF
--- a/mozart-fetcher.spec
+++ b/mozart-fetcher.spec
@@ -50,7 +50,6 @@ systemctl enable cloudformation-signal
 /bin/chown -R component:component /var/log/component
 
 %files
-/home/component
 %attr(0755, component, component) /home/component/component-status-cfn-signal.sh
 /usr/lib/systemd/system/cloudformation-signal.service
 /usr/lib/systemd/system/mozart-fetcher.service

--- a/mozart-fetcher.spec
+++ b/mozart-fetcher.spec
@@ -50,7 +50,7 @@ systemctl enable cloudformation-signal
 /bin/chown -R component:component /var/log/component
 
 %files
-%attr(0755, component, component) /home/component/component-status-cfn-signal.sh
+%attr(0755, component, component) /home/component/*
 /usr/lib/systemd/system/cloudformation-signal.service
 /usr/lib/systemd/system/mozart-fetcher.service
 /var/log/component/app.log


### PR DESCRIPTION
https://jira.dev.bbc.co.uk/browse/RESFRAME-5444

This change solves a warning from Codebuild:

```
warning: File listed twice: /home/component/component-status-cfn-signal.sh
```

I have [deployed this to TEST](https://cosmos.tools.bbc.co.uk/deployments/7967018) and confirmed that `component-status-cfn-signal.sh` can be found in `/home/component`. The component itself `mozart-fetcher` and other files can also be found in the same folder. 

![Screenshot 2023-09-29 at 11 48 46](https://github.com/bbc/mozart-fetcher/assets/39172881/c51627c8-a8a9-4328-a0a5-bd73bc7e5f59)

