### PR TITLE
Add `on-failure: ABORT` to each phase in buildspec

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,13 +4,16 @@ env:
   git-credential-helper: yes
 phases:
   install:
+    on-failure: ABORT
     commands:
       - certee-fetch
   build:
+    on-failure: ABORT
     commands:
       - make dependencies
       - make test
   post_build:
+    on-failure: ABORT
     commands:
       - |
         RELEASABLE_BRANCH=$(git branch --contains ${CODEBUILD_RESOLVED_SOURCE_VERSION} --remote | grep -c -E '^\s*origin/master$' || true)


### PR DESCRIPTION
ISSUE: https://jira.dev.bbc.co.uk/browse/RESFRAME-5465

We want to stop the build as soon as there is a failure. We need to have `on-failure: ABORT` in each phase otherwise the build will continue, even if there's something wrong.