### PR TITLE
feat: add ctx-service-env to FABL calls

### DIFF
--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -36,8 +36,10 @@ defmodule HTTPClient do
     end
   end
 
-  defp set_request_headers("https://fabl.api." <> _),
-    do: [{"accept-encoding", "gzip"}, {"ctx-unwrapped", "1"}]
+  defp set_request_headers("https://fabl.api." <> _) do
+    service_env = if MozartFetcher.environment() === :prod , do: "live", else: "test"
+    [{"accept-encoding", "gzip"}, {"ctx-unwrapped", "1"}, {"ctx-service-env", service_env}]
+  end
 
   defp set_request_headers(_endpoint), do: [{"accept-encoding", "gzip"}]
 


### PR DESCRIPTION
Added support to set the FABL ctx-service-env using a param that can be passed though from the mozart-page-configs.

Context:

This is for migrating the Shothand module form Morph to FABL.

- We will update the [prestige_content](https://github.com/bbc/mozart-routing/blob/master/src/lib/mozart_routing/payloads/prestige_content.rb) routing to use the `renderer-env` override value that is provided to pass though to the page config.

- The [shorthand config](https://github.com/bbc/mozart-page-configs/blob/ece101b15b0f4daf8db91ca046c16c0af8865a2d/configs/prestige_content/shorthand.json) will then be updated to add `&fabl-ctx-service-env={{renderer-env}}` which will be used by the mozart fetch to see the relevant header.

