### PR TITLE
Record as nanoseconds and convert to milliseconds

### DIFF
--- a/lib/mozart_fetcher/fetcher.ex
+++ b/lib/mozart_fetcher/fetcher.ex
@@ -12,7 +12,7 @@ defmodule MozartFetcher.Fetcher do
   end
 
   def process(configs, buffer \\ @timeout_buffer) do
-    before_time = System.monotonic_time(:millisecond)
+    before_time = System.monotonic_time(:nanosecond)
     max_timeout = TimeoutParser.max(configs) + buffer
 
     stream_opts = [
@@ -29,7 +29,7 @@ defmodule MozartFetcher.Fetcher do
       |> decorate_response()
       |> Jason.encode!()
 
-    timing = (System.monotonic_time(:millisecond) - before_time) |> abs
+    timing = (System.monotonic_time(:nanosecond) - before_time) |> abs
     :telemetry.execute([:function, :timing, :fetcher, :process], %{duration: timing})
     decoded_components
   end

--- a/lib/mozart_fetcher/http_client.ex
+++ b/lib/mozart_fetcher/http_client.ex
@@ -5,7 +5,7 @@ defmodule HTTPClient do
 
   def get(endpoint, client \\ client()) do
     try do
-      before_time = System.monotonic_time(:millisecond)
+      before_time = System.monotonic_time(:nanosecond)
       headers = set_request_headers(endpoint)
 
       options = [
@@ -25,7 +25,7 @@ defmodule HTTPClient do
         end
         |> log_errors_and_return()
 
-      timing = (System.monotonic_time(:millisecond) - before_time) |> abs
+      timing = (System.monotonic_time(:nanosecond) - before_time) |> abs
       :telemetry.execute([:function, :timing, :http_client, :get], %{duration: timing})
       response
     rescue

--- a/lib/mozart_fetcher/metric_definitions.ex
+++ b/lib/mozart_fetcher/metric_definitions.ex
@@ -19,11 +19,13 @@ defmodule MozartFetcher.MetricDefinitions do
           counter("error.empty_component_list", event_name: [:error, :empty_component_list]),
           summary("function.timing.fetcher.process",
             event_name: [:function, :timing, :fetcher, :process],
-            measurement: :duration
+            measurement: :duration,
+            unit: {:native, :millisecond}
           ),
           summary("function.timing.http_client.get",
-            event_name: [:function, :timin, :http_client, :get],
-            measurement: :duration
+            event_name: [:function, :timing, :http_client, :get],
+            measurement: :duration,
+            unit: {:native, :millisecond}
           ),
           counter("http.component.retry", event_name: [:http, :component, :retry]),
           counter("http.component.error", event_name: [:http, :component, :error]),
@@ -41,9 +43,10 @@ defmodule MozartFetcher.MetricDefinitions do
             event_name: [:web, :response, :status],
             tags: [:status_code]
           ),
-          counter("web.response.timing",
+          summary("web.response.timing",
             event_name: [:web, :response, :timing],
-            tags: [:status_code]
+            tags: [:status_code],
+            unit: {:native, :millisecond}
           ),
           counter("web.response.timing.page", event_name: [:web, :response, :timing, :page])
         ]

--- a/lib/mozart_fetcher/plugs/page_metrics.ex
+++ b/lib/mozart_fetcher/plugs/page_metrics.ex
@@ -5,11 +5,11 @@ defmodule MozartFetcher.Plug.PageMetrics do
   def init(opts), do: opts
 
   def call(conn, _opts) do
-    before_time = System.monotonic_time(:millisecond)
+    before_time = System.monotonic_time(:nanosecond)
     :telemetry.execute([:web, :request, :count], %{})
 
     register_before_send(conn, fn conn ->
-      timing = (System.monotonic_time(:millisecond) - before_time) |> abs
+      timing = (System.monotonic_time(:nanosecond) - before_time) |> abs
 
       :telemetry.execute([:web, :response, :status], %{}, %{status_code: conn.status})
 


### PR DESCRIPTION
Seems the Belfrage.Metrics.duration function in Belfrage records as nanoseconds and then converts to milliseconds.

Didn't realise we were doing this conversion from where we set to nanoseconds... https://github.com/bbc/belfrage/blob/master/lib/belfrage/metrics.ex#L13 then change to milliseconds in the metric definitions.