### PR TITLE
Rename fabl-ctx-service-env header

### DIFF
--- a/lib/mozart_fetcher/fake_origin.ex
+++ b/lib/mozart_fetcher/fake_origin.ex
@@ -27,7 +27,7 @@ defmodule MozartFetcher.FakeOrigin do
   end
 
   get "/module/metadata" do
-    if get_req_header(conn, "fabl-ctx-service-env") == ["live"] &&
+    if get_req_header(conn, "ctx-service-env") == ["live"] &&
          get_req_header(conn, "ctx-unwrapped") == ["1"] do
       send_resp(
         conn,

--- a/test/http_client_test.exs
+++ b/test/http_client_test.exs
@@ -63,7 +63,7 @@ defmodule HTTPClientTest do
       assert {"ctx-unwrapped", "1"} in resp.request.headers
     end
 
-    test "adds the fabl-ctx-service-env header for FABL requests" do
+    test "adds the ctx-service-env header for FABL requests" do
       defmodule MockClientSuccessfulResponseWithFablCtxServiceEnvHeader do
         def get(endpoint, headers, _) do
           {:ok,
@@ -80,11 +80,11 @@ defmodule HTTPClientTest do
       {:ok, resp} =
         HTTPClient.get(
           "https://fabl.api.something/test",
-          _headers = [{"fabl-ctx-service-env", "test"}],
+          _headers = [{"ctx-service-env", "test"}],
           MockClientSuccessfulResponseWithFablCtxServiceEnvHeader
         )
 
-      assert {"fabl-ctx-service-env", "test"} in resp.request.headers
+      assert {"ctx-service-env", "test"} in resp.request.headers
     end
 
     test "makes only one request on success" do

--- a/test/integration_test.exs
+++ b/test/integration_test.exs
@@ -169,7 +169,7 @@ defmodule MozartFetcher.IntegrationTest do
         "components": [{
                         "endpoint": "localhost:8082/module/metadata",
                         "headers": {
-                          "fabl-ctx-service-env": "live",
+                          "ctx-service-env": "live",
                           "ctx-unwrapped": "1"
                         },
                         "id": "fabl-component",


### PR DESCRIPTION
Rename ctx-service-env header.

https://jira.dev.bbc.co.uk/browse/RESFRAME-5863