### PR TITLE
Set header keys as strings

### DIFF
--- a/lib/mozart_fetcher/component.ex
+++ b/lib/mozart_fetcher/component.ex
@@ -34,10 +34,12 @@ defmodule MozartFetcher.Component do
   end
 
   defp get(config) do
-    headers = config.headers || %{}
+    headers =
+      (config.headers || %{})
+      |> Enum.map(fn {k, v} -> {to_string(k), v} end)
 
     LocalCache.get_or_store(config.endpoint, fn ->
-      HTTPClient.get(config.endpoint, Map.to_list(headers))
+      HTTPClient.get(config.endpoint, headers)
     end)
   end
 


### PR DESCRIPTION
The headers were appearing as atoms. This looks to be due to using a keyword list and not a list of tuples.

The tests look to be using the tuple list format and would have spotted this if using a keyword list.

https://jira.dev.bbc.co.uk/browse/RESFRAME-5863