### PR TITLE
Fix 'warning: the :backends key for the :logger application'

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,3 +5,5 @@ config :logger, :file,
   format: {MozartFetcher.Logger.Formatter, :format},
   metadata: :all,
   level: :error
+
+config :logger, :default_handler, false

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -1,8 +1,5 @@
 import Config
 
-config :logger,
-  backends: [{LoggerFileBackend, :file}]
-
 config :logger, :file,
   path: "/var/log/component/app.log",
   format: {MozartFetcher.Logger.Formatter, :format},

--- a/lib/mozart_fetcher/application.ex
+++ b/lib/mozart_fetcher/application.ex
@@ -32,12 +32,12 @@ defmodule MozartFetcher.Application do
   end
 
   def start(_type, args) do
+    LoggerBackends.add({LoggerFileBackend, :file})
+
     children = children(args)
 
     opts = [strategy: :one_for_one, name: MozartFetcher.Supervisor]
     {:ok, pid} = Supervisor.start_link(children ++ hackney_setup(), opts)
-
-    LoggerBackends.add(LoggerFileBackend)
 
     {:ok, pid}
   end


### PR DESCRIPTION
**ISSUE:** https://bbc.atlassian.net/browse/BELFRAGE-319

# Description
This PR solves following warning
```
warning: the :backends key for the :logger application is deprecated.
Here is how to proceed:

1. If you want to set it to [:console], simply remove the option.

2. If you want to disable logging, remove :backends and instead set:

    config :logger, :default_handler, false

3. If you want to configure any other backend, then it is recommended
   to add `{:logger_backends, "~> 1.0"}` as a dependency and call
   `LoggerBackends.add(CustomBackend)` in your application start callback
```

These changes were needed because newer Elixir versions no longer support configuring custom Logger backends through `config :logger, backends: ...`, so `LoggerFileBackend` must be registered at runtime via `logger_backends` instead. The previous code was not working because `LoggerBackends.add(LoggerFileBackend)` registered only the module, while `LoggerFileBackend` expects the named backend tuple `{LoggerFileBackend, :file}` so it can pick up the existing `config :logger, :file` configuration.

## Test
I deployed the branch to `test`.
The log works `/var/log/component/app.log`
```bash
[aleksander_dimov@ip-10-44-24-232 ~]$ cat /var/log/component/app.log
{"message":"Non-200 response","status":202,"level":"error","component":"weather-watchers","endpoint":"https://component-broker.weather.test.api.bbci.co.uk/component/weather-watchers/?locale=en&news_region_id=22","datetime":"2026-03-23T16:43:22.548022Z"}
```
and no log to the standardout
```bash
[aleksander_dimov@ip-10-44-24-232 ~]$ sudo systemctl status mozart-fetcher.service --no-pager
● mozart-fetcher.service - Start the mozart-fetcher service
     Loaded: loaded (/usr/lib/systemd/system/mozart-fetcher.service; enabled; preset: disabled)
    Drop-In: /etc/systemd/system/mozart-fetcher.service.d
             └─env.conf
     Active: active (running) since Mon 2026-03-23 16:42:36 UTC; 11min ago
   Main PID: 627 (beam.smp)
      Tasks: 26 (limit: 5673)
     Memory: 176.6M (peak: 200.9M)
        CPU: 3.849s
     CGroup: /system.slice/mozart-fetcher.service
             ├─627 /home/component/mozart-fetcher/erts-16.2/bin/beam.smp -- -root /home/component/mozart-fetcher -…
             ├─700 /home/component/mozart-fetcher/erts-16.2/bin/epmd -daemon
             ├─707 erl_child_setup 1024
             ├─880 /home/component/mozart-fetcher/erts-16.2/bin/inet_gethost 4
             ├─881 /home/component/mozart-fetcher/erts-16.2/bin/inet_gethost 4
             ├─882 /home/component/mozart-fetcher/erts-16.2/bin/inet_gethost 4
             └─883 /home/component/mozart-fetcher/erts-16.2/bin/inet_gethost 4

Mar 23 16:42:36 ip-10-44-24-232 systemd[1]: Started Start the mozart-fetcher service.
```